### PR TITLE
Каждому -- свой .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,11 +11,12 @@
     "indent": 4,
     "latedef": true,
     "sub": true,
-    "newcap": true,
+    "newcap": false,
     "noarg": true,
     "noempty": true,
     "nonew": true,
     "onevar": false,
     "undef": true,
-    "unused": true
+    "unused": false,
+    "white": false
 }


### PR DESCRIPTION
Может уберём из репа общий .jshintrc?
А то сейчас там куча ошибок при анализе файлов.
А у меня стоит git hook для проверки всех js файлов изменённых jshint'ом при коммите.
