### PR TITLE
Порядок событий при изменении модели

### DIFF
--- a/src/ns.model.js
+++ b/src/ns.model.js
@@ -340,7 +340,10 @@ ns.Model.prototype.set = function(jpath, value, options) {
     //  Пока что будет версия без сравнения.
 
     if ( !(options && options.silent) ) {
-        //  Кидаем сообщения о том, что модель (или ее часть) изменилась.
+        //  Сообщение о том, что вообще вся модель изменилась.
+        this.trigger('ns-model-changed', jpath);
+
+        //  Кидаем сообщения о том, что изменились части модели.
         //  Например, если jpath был '.foo.bar', то кидаем два сообщения: 'changed.foo.bar' и 'changed.foo'.
         //  В качестве параметра (пока что) этот же самый jpath.
         //
@@ -356,8 +359,6 @@ ns.Model.prototype.set = function(jpath, value, options) {
             this.trigger('ns-model-changed' + _jpath, _jpath);
             l--;
         }
-        //  Сообщение о том, что вообще вся модель изменилась.
-        this.trigger('ns-model-changed', jpath);
     }
 };
 


### PR DESCRIPTION
Сейчас наши супермодельки при `.set` кидают пачку событий.
Сначала идут события с jpath типа `ns-model-changed.{jpath}`, а затем просто `ns-model-changed`.
ns.Update завязан на то, что при изменении модели вьюшка автоматом инвалидируется. Т.е. ns.View честно подписывается на `ns-model-changed` для инвалидации.
Если предприимчивый разработчик подпишется на `ns-model-changed.{jpath}`, да ещё и сделает там page.go, то Update начнётся до того, как ns.View, зависящий от этой модели, проинвалидируется. В такой ситуации возможны баги при рендеринге, обновлении, перерисовке итд.

Что я сделал: я поменял порядок событий. Сначала `ns-model-changed`, затем кастомные `ns-model-changed.{jpath}`. Так мы почти гарантируем, что обработчики, висящие на change у модели выполнятся после обработчика от ns.View.

Рассматривал и другие способы решения:
- добавить другое событие, например `ns-model-set`
- запускать обработчики с нулевым таймаутом.
  Первый способ показался наиболее адекватным.

Тесты работают.

cc @doochik @chestozo 
