### PR TITLE
prevent to create a new history record by replacing a history state

### DIFF
--- a/src/ns.page.js
+++ b/src/ns.page.js
@@ -71,6 +71,8 @@ ns.page.go = function(url, preventAddingToHistory) {
     if (!preventAddingToHistory) {
         // записываем в историю все переходы
         ns.history.pushState(url);
+    } else {
+        ns.history.replaceState(url);
     }
 
     ns.page.history.push(url);


### PR DESCRIPTION
Сейчас если передать true в ns.page.go и изменить url, переход не происходит (т.к. стейт не реплейсится). Поправил это дело
