### PR TITLE
Возможность загрузить модель с произвольного url

### DIFF
--- a/src/ns.model.js
+++ b/src/ns.model.js
@@ -140,6 +140,7 @@ ns.Model.prototype._prepareCallback = function(method) {
  * @param {Function} [info.ctor] Конструтор.
  * @param {Object} [info.methods] Методы прототипа.
  * @param {Object} [info.params] Параметры модели, участвующие в формировании уникального ключа.
+ * @param {Object} [info.request] Декларация способа загрузки модели для request.
  * @param {ns.Model} [base=ns.Model] Базовый класс для наследования
  * @examples
  * //  Простая модель, без параметров.
@@ -217,6 +218,13 @@ ns.Model.info = function(id) {
          * @type {Object}
          */
         info.events = info.events || {};
+
+        /**
+         * Определение url и type запроса. Если null,
+         * то Request соберет url сам
+         * @type {Object|null}
+         */
+        info.request = info.request || null;
 
         info.pNames = Object.keys(info.params);
 


### PR DESCRIPTION
_Предыстория_: в [моем проекте](http://catatron.com/repo-list/noscript/) я загружаю данные через API Github, поэтому нужно брать данные с определенного url и через GET. Приходится это делать перед вызовом `ns.init()`, а это может блокировать работу остальных компонентов, если api будет долго отвечать.

Этот коммит дает возможность определить источник загрузки модели. Для этого вводится дополнительное поле request в определение модели:

``` javascript
ns.Model.define('repositories', {
  request: {
    method: 'GET',
    url: 'https://api.github.com/users/yandex-ui/repos'
  }
});
```

Теперь все загрузки этой модели будут ходить через этот url и при этом ничего не будут блокировать.
Совместимость со старой схемой и возможность загружать обоими способами сразу описана в тестах.
