### PR TITLE
Возможность вызова методов вида из шаблона

### DIFF
--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -711,6 +711,8 @@
     ns.View.prototype._getViewTree = function(layout, params) {
         var tree = {
             async: false,
+            // инстанс, чтобы работал ns-view-call
+            instance: this,
             // фейковое дерево, чтобы удобно матчится в yate
             tree: {},
             // всегда собираем данные, в том числе закешированные модели для async-view

--- a/test/spec/yate.check.js
+++ b/test/spec/yate.check.js
@@ -1,3 +1,30 @@
 it('Check yate templates are ready [run `make yate` if it fails]', function() {
     expect(yr.run('main', {}, 'check-yate-is-ready')).to.be.equal('Ready');
 });
+
+it('Check ns-view-call', function(finish) {
+    var result = yr.run('main', {}, 'check-yate-is-ready');
+
+    ns.View.define('app-ns-view-call', {
+        methods: {
+            someViewMethod: function() {
+                return 'method result';
+            }
+        }
+    });
+    ns.layout.define('app', {
+        'app-ns-view-call': {}
+    });
+
+    this.APP = ns.View.create('app-ns-view-call');
+    var that = this;
+    new ns.Update(
+        this.APP,
+        ns.layout.page('app', {}),
+        {}
+    ).start().then(function() {
+        var html = that.APP.node.innerHTML;
+        expect(html).to.contain('<div class="js-test-call">method result</div>');
+        finish();
+    }, finish);
+});

--- a/test/tests.yate
+++ b/test/tests.yate
@@ -31,3 +31,9 @@ match .app-subview-01 ns-view-content {
         /.models.data.data
     </div>
 }
+
+match .app-ns-view-call ns-view-content {
+    <div class="js-test-call">
+        ns-view-call('someViewMethod')
+    </div>
+}

--- a/yate/noscript-yate-externals.js
+++ b/yate/noscript-yate-externals.js
@@ -6,3 +6,17 @@
 yr.externals['ns-url'] = function(path) {
     return ns.router.url(path);
 };
+
+/**
+ * Мост в JS для вызова метода вида
+ * @private
+ */
+yr.externals['_ns-view-call'] = function(view, methodName, p1, p2, p3, p4, p5) {
+    view = yr.nodeset2data(view);
+    var result = view[methodName](p1, p2, p3, p4, p5);
+    if (Array.isArray(result)) {
+        return yr.array2nodeset(result);
+    } else {
+        return yr.object2nodeset(result);
+    }
+};

--- a/yate/noscript.yate
+++ b/yate/noscript.yate
@@ -4,6 +4,21 @@
 
 external scalar ns-url(scalar)
 
+/**
+ * Мост в JS для вызова метода вида
+ * @private
+ */
+external nodeset _ns-view-call(nodeset, scalar, nodeset, nodeset, nodeset, nodeset, nodeset)
+
+/**
+ * Вызывает methodName текущего вида
+ * @param {...*} Аргументы
+ * @returns nodeset
+ */
+func ns-view-call(scalar methodName, nodeset p1, nodeset p2, nodeset p3, nodeset p4, nodeset p5) {
+    _ns-view-call(/.instance, methodName, p1, p2, p3, p4, p4)
+}
+
 //  Ключ для получения моделей по имени.
 key model( /.models.*, name() ) { . }
 


### PR DESCRIPTION
`ns-view-call` позволяет вызывать высокоуровненые методы вида из шаблона.

У нас это многие просят. Вот несколько полезных нам примеров.
1. Виджетная система. В одной коллекции каждый элемент может быть как обычным, так и виджетом. Виджетность определяется как на основе объективным данных из модели, так и необъективных (браузер, пользователь, настрйки и т.п.). Отрисовка соответственно меняется. Сейчас у нас одинаковые условия дублируются js и yate. Хотя ребята закостылили что-то подобное `ns-view-call`. Делать бесконечное количество флагов и матчится на них тоже плохо.
2. Получение выборки данных. В модели у нас храняться данные в наиболее используемом виде, но иногда оттуда надо делать выборку как в js, так и yate. Например, выбрать всех адресатов, которые не "я", или выбрать их по типу. Сейчас эта логика опять же продублирована.

В тестах есть пример

```
match .app-ns-view-call ns-view-content {
    <div class="js-test-call">
        ns-view-call('someViewMethod')
    </div>
}
```

У инстанса вида вызывается его метод `someViewMethod`. Это никакая ни обертка или что-то подобное. Все по-честному.
