### PR TITLE
[ns.View] updateTree и хелпер для получения ошибок модели

### DIFF
--- a/yate/noscript.yate
+++ b/yate/noscript.yate
@@ -4,8 +4,19 @@
 
 external scalar ns-url(scalar)
 
-//  Ключ для получения моделей по имени.
+/**
+ * Ключ для получения данных модели
+ * @example
+ * data = model('name')
+ */
 key model( /.models.*, name() ) { . }
+
+/**
+ * Ключ для получения ошибки модели
+ * @example
+ * error = modelError('name')
+ */
+key modelError( /.errors.*, name() ) { . }
 
 // @private
 match / {


### PR DESCRIPTION
Задача из #261 

Просто для консистентности, у нас есть хелпер `model()`,  но нет хелпера `modelError()` и для получения ошибки придется лезть в дерево руками.
