### PR TITLE
[ns.View] updateTree и прокидывание ns.page.current

### DIFF
--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -715,8 +715,6 @@
         tree.errors = this._getModelsError();
         // если view находится в режиме async, то модели проверять не надо
         tree.is_models_valid = this.asyncState || this.isModelsValid();
-        //  FIXME: Не должно ли оно приходить в параметрах Update'а?
-        tree.page = ns.page.current;
 
         //  Если это асинхронный блок и для него нет еще всех моделей,
         //  помечаем его как асинхронный.
@@ -879,8 +877,7 @@
         }
 
         var tree = {
-            models: this._getModelsData(),
-            page: ns.page.current
+            models: this._getModelsData()
         };
 
         if (extra) {

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -315,7 +315,6 @@ ns.ViewCollection.prototype._getViewTree = function(layout, params) {
     tree.collection = true;
     // всегда собираем данные, в том числе закешированные модели для async-view
     tree.models = this._getModelsData();
-    tree.page = ns.page.current;
 
     //  Если это асинхронный блок и для него на самом деле нет еще всех моделей,
     //  помечаем его как асинхронный (false).

--- a/test/spec/ns.updater.js
+++ b/test/spec/ns.updater.js
@@ -463,7 +463,6 @@ describe('no.Updater', function() {
                     'main': {
                         'async': false,
                         'models': {},
-                        'page': {},
                         'params': {},
                         'tree': {
                             'main': true


### PR DESCRIPTION
Задача из #261

Зачем мы прокидываем в дерево `ns.page.current`, если можно это сделать external-функцией.
Я бы сделал две функции
`ns-page-layout()` - возвращает `ns.page.current.page`, это название layout, который сейчас рисуется
`ns-page-params()` - возвращает `ns.page.current.params`, это текущие параметры страница
