### PR TITLE
[ns.View] updateTree и common-дерево

### DIFF
--- a/build/src.client.js
+++ b/build/src.client.js
@@ -18,7 +18,6 @@
     /* borschik:include:../src/ns.profile.js */
 
     /* borschik:include:../src/ns.action.js */
-    /* borschik:include:../src/ns.box.js */
     /* borschik:include:../src/ns.model.js */
     /* borschik:include:../src/ns.modelCollection.js */
     /* borschik:include:../src/ns.layout.js */
@@ -31,6 +30,9 @@
     /* borschik:include:../src/ns.update.js */
     /* borschik:include:../src/ns.view.js */
     /* borschik:include:../src/ns.viewCollection.js */
+
+    // ns.box должен подключаться после ns.view, т.к. берет методы из него
+    /* borschik:include:../src/ns.box.js */
 
     window.no = no;
     window.ns = ns;

--- a/build/src.server.js
+++ b/build/src.server.js
@@ -11,7 +11,6 @@ var no = require('nommon');
 /* borschik:include:../src/ns.object.js */
 /* borschik:include:../src/ns.profile.js */
 
-/* borschik:include:../src/ns.box.js */
 /* borschik:include:../src/ns.model.js */
 /* borschik:include:../src/ns.modelCollection.js */
 /* borschik:include:../src/ns.layout.js */
@@ -22,5 +21,8 @@ var no = require('nommon');
 /* borschik:include:../src/ns.update.js */
 /* borschik:include:../src/ns.view.js */
 /* borschik:include:../src/ns.viewCollection.js */
+
+// ns.box должен подключаться после ns.view, т.к. берет методы из него
+/* borschik:include:../src/ns.box.js */
 
 module.exports = ns;

--- a/doc/ns.view.yate.md
+++ b/doc/ns.view.yate.md
@@ -105,31 +105,31 @@ match .my-view-collection ns-view-content {
 
 ```js
 {
-    async: false,
     box: false,
     collection: false,
-    errors: {
-        model3: {
-            error: 'http_timeout'
-        }
-    },
-    is_models_valid: true,
     key: 'view=app',
     models: {
-        model1: {}
-        model2: {}
+        model1: {
+            'data': {},
+            'status': 'ok'
+        },
+        model2: {
+            'data': {},
+            'status': 'ok'
+        },
+        model3: {
+            data: 'http_timeout',
+            'status': 'error'
+        }
     },
-    page: {},
     params: {},
-    placeholder: false,
+    state: 'ok',
     views: {}
 }
 ```
 
 **Публичные свойства**:
- - `is_models_valid`: boolean. Флаг валидности моделей вида.
  - `key`: string. Ключ вида.
- - `page`: object. Ссылка на объект `ns.page.current`.
  - `params`: object. Собственные параметры вида.
  - `views`: object. Объект с дочерними видами, используется для дальнейшего наложения шаблонов через ns-view-content. Имеет следующий вид:
 ```
@@ -142,9 +142,7 @@ match .my-view-collection ns-view-content {
 ```
 
 **Приватные свойства**:
- - `async`: boolean. Флаг указывающий, что вид сейчас не готов и у него вызывается `ns-view-async-content`
  - `box`: boolean. Флаг того, что это бокс.
  - `collection`: boolean. Флаг того, что это вид-коллекция.
- - `errors`: object. Объект с моделями, для которых не удалось получить данные и сами данные ошибки. Не стоит использовать его напрямую. Лучше вызывать yate-функцию `modelError()`.
- - `models`: object. Объект с данными моделей. Не стоит использовать его напрямую. Лучше вызывать yate-функцию `model()`.
- - `placeholder`: boolean. Флаг того, что этот вид валиден и будут отрисованы только его дети.
+ - `models`: object. Объект с данными моделей. Не стоит использовать его напрямую. Лучше вызывать yate-функции `model()` и `modelError()`.
+ - `state`: Текущее состояние вида. ok/error/loading/placeholder

--- a/src/ns.box.js
+++ b/src/ns.box.js
@@ -20,6 +20,8 @@ ns.Box = function(id, params) {
     this._visible = false;
 };
 
+ns.Box.prototype._getCommonTree = ns.View.prototype._getCommonTree;
+
 /**
  *
  * @param {string} id
@@ -119,19 +121,8 @@ ns.Box.prototype._getUpdateTree = function(tree, layout, params) {
  * @private
  */
 ns.Box.prototype._getViewTree = function(layout, params) {
-    //  Для бокса это всегда объект (возможно, пустой).
-    var tree = {
-        async: false,
-        box: true,
-        collection: false,
-        key: this.key,
-        is_models_valid: true,
-        placeholder: false,
-        tree: {},
-        views: {}
-    };
-
-    tree.tree[this.id] = true;
+    var tree = this._getCommonTree();
+    tree.box = true;
 
     var views = this.views;
     for (var id in layout) {

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -228,7 +228,7 @@ ns.ViewCollection.prototype._getRequestViews = ns.View.prototype._tryPushToReque
  * @param {object} tree
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @returns {ns.View~UpdateTree}
  * @private
  */
 ns.ViewCollection.prototype._getUpdateTree = function(tree, layout, params) {
@@ -249,7 +249,7 @@ ns.ViewCollection.prototype._getUpdateTree = function(tree, layout, params) {
  *
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @returns {object.<string, ns.View~UpdateTree>}
  * @private
  */
 ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
@@ -305,14 +305,14 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
  *
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @returns {ns.View~UpdateTree}
  * @private
  */
 ns.ViewCollection.prototype._getViewTree = function(layout, params) {
     var tree = this._getTree();
     tree.collection = true;
     // всегда собираем данные, в том числе закешированные модели для async-view
-    tree.models = this._getModelsData();
+    tree.models = this._getModelsForTree();
 
     tree.views = this._getDescViewTree(layout, params);
 

--- a/test/spec/ns.updater.js
+++ b/test/spec/ns.updater.js
@@ -744,7 +744,6 @@ describe('ns.Updater', function() {
             var renderJSON = {
                 'views': {
                     'main': {
-                        'async': false,
                         'models': {},
                         'params': {},
                         'tree': {

--- a/test/spec/ns.view.errors.js
+++ b/test/spec/ns.view.errors.js
@@ -57,15 +57,16 @@ describe('ns.View error handling', function() {
                 var renderJSON = {
                     'views': {
                         'app': {
-                            'is_models_valid': true,
+                            'state': 'ok',
                             'models': {},
-                            'errors': {},
                             'views': {
                                 'letter': {
-                                    'is_models_valid': false,
-                                    'models': {},
-                                    'errors': {
-                                        'letter': 'letter not found'
+                                    'state': 'error',
+                                    'models': {
+                                        'letter': {
+                                            'status': 'error',
+                                            'data': 'letter not found'
+                                        }
                                     }
                                 }
                             }

--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -254,11 +254,33 @@ describe('ns.View', function() {
             c.setError({ error: 'c invalid' });
 
             var view = ns.View.create('test-view-render_complex', {}, false);
+            view.tmpl();
 
-            expect( view._getModelsData() ).to.be.eql({
-                a: { data: 'a' },
-                b: { error: 'b invalid' },
-                c: { error: 'c invalid' }
+            expect(ns.renderNode).to.be.calledWithMatch({
+                views: {
+                    'test-view-render_complex': {
+                        models: {
+                            a: {
+                                data: {
+                                    data: 'a'
+                                },
+                                status: 'ok'
+                            },
+                            b: {
+                                data: {
+                                    error: 'b invalid'
+                                },
+                                status: 'error'
+                            },
+                            c: {
+                                data: {
+                                    error: 'c invalid'
+                                },
+                                status: 'error'
+                            }
+                        }
+                    }
+                }
             });
         });
     });

--- a/test/spec/yate.helpers.js
+++ b/test/spec/yate.helpers.js
@@ -1,0 +1,45 @@
+describe('хелперы yate', function() {
+
+    describe('доступ к данными модели', function() {
+
+        beforeEach(function() {
+            ns.Model.define('a');
+            ns.Model.define('b');
+            ns.Model.define('c');
+
+            ns.View.define('test-yate-helper-model', {
+                models: {
+                    a: true,
+                    b: false
+                }
+            });
+
+            ns.Model.get('a').setData('model-a-data');
+            ns.Model.get('b').setError('model-b-error');
+
+            this.result = ns.View.create('test-yate-helper-model', {}, false).tmpl().innerHTML;
+        });
+
+        afterEach(function() {
+            delete this.result;
+        });
+
+        it('model() должен вернуть данные валидной модели', function() {
+            expect(this.result).to.have.string('<div class="data">model-a-data</div>');
+        });
+
+        it('model() не должен вернуть данные невалидной модели', function() {
+            expect(this.result).to.not.have.string('<div class="data">model-b-error</div>');
+        });
+
+        it('modelError() должен вернуть ошибку невалидной модели', function() {
+            expect(this.result).to.have.string('<div class="error">model-b-error</div>');
+        });
+
+        it('modelError() не должен вернуть ошибку валидной модели', function() {
+            expect(this.result).to.not.have.string('<div class="error">model-a-data</div>');
+        });
+
+    });
+
+});

--- a/test/tests.yate
+++ b/test/tests.yate
@@ -30,3 +30,18 @@ match / generate-url {
         })
     </a>
 }
+
+match .test-yate-helper-model ns-view-content {
+    <div class="data">
+        model('a')
+    </div>
+    <div class="data">
+        model('b')
+    </div>
+    <div class="error">
+        modelError('a')
+    </div>
+    <div class="error">
+        modelError('b')
+    </div>
+}

--- a/yate/noscript.yate
+++ b/yate/noscript.yate
@@ -14,14 +14,18 @@ external scalar ns-generate-url(/* layout */scalar, /* params */object)
  * @example
  * data = model('name')
  */
-key model( /.models.*, name() ) { . }
+key model( /.models.*[ .status == 'ok' ], name() ) {
+    .data
+}
 
 /**
  * Ключ для получения ошибки модели
  * @example
  * error = modelError('name')
  */
-key modelError( /.errors.*, name() ) { . }
+key modelError( /.models.*[ .status == 'error' ], name() ) {
+    .data
+}
 
 // @private
 match / {
@@ -42,22 +46,24 @@ match .* ns-view {
 // @private
 match .* ns-build-view {
     <div class="ns-view-{ name() }" data-key="{ /.key }">
-        if /.placeholder {
+        state = scalar(/.state)
+
+        if state == 'placeholder' {
             @class += ' ns-view-placeholder'
             apply . ns-view-desc
-        } else {
 
+        } else {
             @class += apply . ns-view-add-class
             apply . ns-view-add-attrs
-            if /.async {
-                apply . ns-view-async-content
-            } else {
-                if !/.is_models_valid {
-                    apply . ns-view-error-content
 
-                } else {
-                    apply . ns-view-content
-                }
+            if state == 'loading' {
+                apply . ns-view-async-content
+
+            } else if state == 'error' {
+                apply . ns-view-error-content
+
+            } else {
+                apply . ns-view-content
             }
         }
     </div>


### PR DESCRIPTION
Задача из #261 

Тут есть две подзадачи, мне кажется они пересекаются
1. Дерево генерируют `view`, `viewcollection` и `box`. Кажется надо `ns.View#_getTree` занаследовать в box, тоже. В общем, по максимум убрать дублирование генерации свойств дерева.
2. `is_models_valid` хочется заменить на более красивый флаг, например, `errorState`, чтобы говорить не "почему", а говорить о текущем состоянии вида. Я исхожу из той логики, что сейчас флаги `async`, `placeholder` и `box` говорят о состоянии вида и не говорят почему они там оказались (оно и не надо), а `is_models_valid` не говорит о состоянии вида, но говорит почему он там оказался и почему у него вызвался `ns-view-error-content`. Я бы тут вообще все флаги куда-то унес, например, в объект state

```
{
  "state": {
    "async": false,
    "box": false,
    "error": true,
    "placeholder": false
   }
}
```
