### PR TITLE
Разделить ns.update на стадии и сформировать из них сценарии

### DIFF
--- a/doc/ns.init.md
+++ b/doc/ns.init.md
@@ -111,13 +111,13 @@ ns.request.canProcessResponse = function(response) {
 параметров страницы и текущего лейаута:
 
 ```js
-ns.Update.prototype.render = function(tree, params, layout) {
+ns.Update.prototype._applyTemplate = function(tree, params, layout) {
     var module = 'main';
 
     if (params.context === 'setup') {
         module = 'setup';
     }
 
-    return ns.tmpl(tree, null, module);
+    return ns.renderString(tree, null, module);
 };
 ```

--- a/src/ns.js
+++ b/src/ns.js
@@ -76,9 +76,12 @@ ns.parseQuery = function(s) {
  * @param {string} [module='main']
  * @returns {Element}
  */
-ns.tmpl = function(json, mode, module) {
-    var result = yr.run(module || 'main', json, mode);
-    return ns.html2node(result);
+ns.renderString = function(json, mode, module) {
+    return yr.run(module || 'main', json, mode);
+};
+
+ns.renderNode = function(json, mode, module) {
+    return ns.html2node(this.renderString(json, mode, module));
 };
 
 /**

--- a/src/ns.profile.js
+++ b/src/ns.profile.js
@@ -43,6 +43,16 @@
     };
 
     /**
+     * Останавливает отсчёт метрики from и начинает отсчёт метрики to
+     * @param {string} from Название останавливаемой метрики
+     * @param {string} to Название запускаемой метрики
+     */
+    ns.profile.switchTimer = function(from, to) {
+        this.stopTimer(from);
+        this.startTimer(to);
+    };
+
+    /**
      * Возвращает значение метрики.
      * @param {string} label Название метрики.
      * @returns {number}
@@ -54,6 +64,14 @@
         // проверяем typeof, чтобы возвращать 0
         var value = this._profileTimes[label];
         return typeof value === 'number' ? value : NaN;
+    };
+
+    /**
+     * Возвращает все значения метрики
+     * @returns {object}
+     */
+    ns.profile.getTimers = function() {
+        return no.extend({}, this._profileTimes);
     };
 
 })();

--- a/src/ns.request.js
+++ b/src/ns.request.js
@@ -314,7 +314,11 @@
                     if (ns.request.canProcessResponse(r) === false) {
                         // если ответ обработать нельзя, то удаляем модели из запроса и отклоняем промис
                         ns.request.Manager.clean(that.models);
-                        that.promise.reject('CANT_PROCESS');
+                        that.promise.reject({
+                            error: 'CANT_PROCESS',
+                            invalid: that.models,
+                            valid: []
+                        });
 
                     } else {
                         that.extract(requesting, r);
@@ -339,8 +343,30 @@
             // вызываем чистку менеджера
             ns.request.Manager.clean(this.models);
 
-            // и резолвим весь ns.request
-            this.promise.fulfill(this.models);
+            // сортируем модели на валидные и нет
+            var validModels = [];
+            var invalidModels = [];
+
+            for (var i = 0, j = this.models.length; i < j; i++) {
+                var model = this.models[i];
+                if (model.isValid()) {
+                    validModels.push(model);
+                } else {
+                    invalidModels.push(model);
+                }
+            }
+
+            // если есть невалидные модели
+            if (invalidModels.length) {
+                this.promise.reject({
+                    invalid: invalidModels,
+                    valid: validModels
+                });
+
+            } else {
+                // и резолвим весь ns.request
+                this.promise.fulfill(this.models);
+            }
         }
     };
 

--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -75,7 +75,7 @@
         this._modelsHandlers = {};
 
         this.node = null;
-        this.views = null;
+        this.views = {};
 
         /**
          * Статус View.
@@ -584,19 +584,12 @@
      * @private
      */
     ns.View.prototype._getRequestViews = function(updated, pageLayout, params) {
-
         // При необходимости добавим текущий вид в список "запрашиваемых"
         this._tryPushToRequest(updated);
 
-        // Если views еще не определены (первая отрисовка)
-        if (!this.views) {
-            //  FIXME: Почему бы это в конструкторе не делать?
-            //  chestozo: lazy инициализация, всё такое.
-            this.views = {};
-            // Создаем подблоки
-            for (var view_id in pageLayout) {
-                this._addView(view_id, params, pageLayout[view_id].type);
-            }
+        // Создаем подблоки
+        for (var view_id in pageLayout) {
+            this._addView(view_id, params, pageLayout[view_id].type);
         }
 
         this._apply(function(view, id) {
@@ -621,6 +614,7 @@
         if (this.async) {
             var hasValidModels = this.isModelsValid();
             var hasValidStatus = this.isOk();
+
             if (hasValidModels && !hasValidStatus) {
                 // если асинхронный блок имеет валидные модели, но невалидный статус - рисуем его синхронно
                 updated.sync.push(this);
@@ -882,7 +876,7 @@
             tree.extra = extra;
         }
 
-        return ns.tmpl(tree, mode);
+        return ns.renderNode(tree, mode);
     };
 
     /**

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -90,8 +90,6 @@ ns.ViewCollection._expandModelsDecl = function(decls) {
  */
 ns.ViewCollection.prototype._init = function() {
     ns.View.prototype._init.apply(this, arguments);
-
-    this.views = {};
 };
 
 /**

--- a/test/spec/ns.request.js
+++ b/test/spec/ns.request.js
@@ -590,7 +590,8 @@ describe('ns.request.js', function() {
 
         it('if model was requested and request was done it does not mean that we model is ok', function(done) {
             var wait = 2;
-            var handleModels = function(models) {
+            var handleModels = function(err) {
+                var models = err.invalid
                 var model1 = models[0];
                 var model2 = models[1];
 
@@ -609,8 +610,8 @@ describe('ns.request.js', function() {
             // Тут какая-то хитрая комбинация запросов должна была быть, чтобы в какой-то момент при запросе модели она бы оказалась
             // уже запрошена и мы бы просто проставили ей руками статус ok.
 
-            ns.request([ 'model1', 'model2' ]).done(handleModels);
-            ns.request('model1').done(handleModels);
+            ns.request([ 'model1', 'model2' ]).then(null, handleModels);
+            ns.request('model1').then(null, handleModels);
         });
 
     });

--- a/test/spec/ns.updater.js
+++ b/test/spec/ns.updater.js
@@ -1,48 +1,286 @@
-describe('no.Updater', function() {
+describe('ns.Updater', function() {
 
-    describe('#perf()', function() {
+    describe('scenario', function() {
+        beforeEach(function() {
+            ns.layout.define('asyncLayout', {
+                'app': {
+                    'vSync0':   ['vSync1', 'vSync2'],
+                    'vAsync1&': ['vSync3', 'vSync4'],
+                    'vAsync2&': true
+                }
+            });
 
-        beforeEach(function(done) {
+            ns.layout.define('syncLayout', {
+                'app': {
+                    'vSync0': ['vSync1', 'vSync2'],
+                    'vSync3': {},
+                    'vSync4': {}
+                }
+            });
+
+            ns.View.define('app');
+            this.view = ns.View.create('app');
+
+            ns.View.define('vSync0', {models: ['mSync1']});
+            ns.View.define('vSync1');
+            ns.View.define('vSync2', {models: ['mSync2']});
+            ns.View.define('vSync3', {models: ['mSync3']});
+            ns.View.define('vSync4');
+
+            ns.View.define('vAsync1', {models: ['mAsync1']});
+            ns.View.define('vAsync2', {models: ['mAsync2']});
+            
+
+            ns.Model.define('mSync1'); ns.Model.define('mSync2'); ns.Model.define('mSync3');
+            ns.Model.define('mAsync1'); ns.Model.define('mAsync2');
+
+            this.response0 = JSON.stringify({
+                "models": [
+                    {"data": {"sync1": true}},
+                    {"data": {"sync2": true}},
+                    {"data": {"sync3": true}}
+                ]
+            });
+
+            this.response1 = JSON.stringify({
+                "models": [
+                    {"data": {"async1": true}}
+                ]
+            });
+
+            this.response2 = JSON.stringify({
+                "models": [
+                    {"data": {"async2": true}}
+                ]
+            });
 
             this.sinon.spy(ns.Update.prototype, 'perf');
+        });
 
-            ns.layout.define('app', {
-                'app': true
-            });
-
-            ns.Model.define('photo');
-            ns.View.define('app', { models: ['photo'] });
-
-            this.sinon.server.autoRespond = true;
-            this.sinon.server.respondWith(function(xhr) {
-                xhr.respond(200, { "Content-Type": "application/json" }, '{ "models": [ { "data": {} } ] }');
-            });
-
-            this.view = ns.View.create('app');
-            var layout = ns.layout.page('app', {});
-            new ns.Update(this.view, layout, {})
-                .start()
-                .then(function() {
+        describe('prefetch', function() {
+            beforeEach(function(done) {
+                this.update = new ns.Update(this.view, ns.layout.page('asyncLayout', {}), {});
+                this.update.prefetch().then(function() {
                     done();
-                }, function(e) {
-                    done(e || 'failed')
                 });
+                this.sinon.server.requests[0].respond(200, {"Content-Type": "application/json"}, this.response0);
+            });
+
+            it('should make all models of sync views valid', function() {
+                expect(ns.Model.get('mSync1').isValid()).to.be.ok;
+                expect(ns.Model.get('mSync2').isValid()).to.be.ok;
+                expect(ns.Model.get('mSync3').isValid()).to.be.ok;
+            });
+
+            it('should leave all models of async views invalid', function() {
+                expect(ns.Model.get('mAsync1').isValid()).not.to.be.ok;
+                expect(ns.Model.get('mAsync2').isValid()).not.to.be.ok;
+            });
+
+            it('should call perf once', function() {
+                expect(ns.Update.prototype.perf).to.have.been.calledOnce;
+            });
+
+            it('should have had profiled stages `collectModels`, `requestSyncModels`', function() {
+                var arg = ns.Update.prototype.perf.getCall(0).args[0];
+                expect(arg).to.have.property('collectModels').that.is.at.least(0);
+                expect(arg).to.have.property('requestSyncModels').that.is.at.least(0);
+            });
         });
 
-        it('должен вызваться perf после завершения обновления', function() {
-            expect(ns.Update.prototype.perf).to.have.been.calledOnce;
+        describe('generateHTML', function() {
+            beforeEach(function(done) {
+                this.update = new ns.Update(this.view, ns.layout.page('asyncLayout', {}), {});
+                this.update.generateHTML()
+                    .then(function(html) {
+                        this.$node = $(ns.html2node(html));
+                        done();
+                    }, this);
+
+                this.sinon.server.requests[0].respond(200, {"Content-Type": "application/json"}, this.response0);
+            });
+
+            it('should create correctly nested nodes of sync views', function() {
+                var vSync0node = this.$node.find('.ns-view-vSync0');
+
+                expect(vSync0node.length).to.equal(1);
+                expect(vSync0node.find('.ns-view-vSync1').length).to.equal(1);
+                expect(vSync0node.find('.ns-view-vSync2').length).to.equal(1);
+            });
+
+            it('should create nodes of async views', function() {
+                expect(this.$node.find('.ns-view-vAsync1').length).to.equal(1);
+                expect(this.$node.find('.ns-view-vAsync2').length).to.equal(1);
+            });
+
+            it('should turn nodes of async views into async mode', function() {
+                expect(this.$node.find('.ns-view-vAsync1.ns-async').length).to.equal(1);
+                expect(this.$node.find('.ns-view-vAsync2.ns-async').length).to.equal(1);
+            });
+
+            it('should not create nodes of async views descendants', function() {
+                expect(this.$node.find('.ns-view-vAsync3').length).to.equal(0);
+                expect(this.$node.find('.ns-view-vAsync3').length).to.equal(0);
+            });
+
+            it('should call perf once', function() {
+                expect(ns.Update.prototype.perf).to.have.been.calledOnce;
+            });
+
+            it('should have had profiled stages `collectModels`, `requestSyncModels`, `collectViews`, `generateHTML`', function() {
+                var arg = ns.Update.prototype.perf.getCall(0).args[0];
+                expect(arg).to.have.property('collectModels').that.is.at.least(0);
+                expect(arg).to.have.property('requestSyncModels').that.is.at.least(0);
+                expect(arg).to.have.property('collectViews').that.is.at.least(0);
+                expect(arg).to.have.property('generateHTML').that.is.at.least(0);
+            });
         });
 
-        it('должен вызваться perf c правильными данными после завершения обновления', function() {
-            var arg = ns.Update.prototype.perf.getCall(0).args[0];
-            expect(arg).to.have.property('prepare').that.is.at.least(0);
-            expect(arg).to.have.property('request').that.is.at.least(0);
-            expect(arg).to.have.property('tree').that.is.at.least(0);
-            expect(arg).to.have.property('template').that.is.at.least(0);
-            expect(arg).to.have.property('dom').that.is.at.least(0);
-            expect(arg).to.have.property('events').that.is.at.least(0);
+        describe('render (sync layout)', function() {
+            beforeEach(function(done) {
+                this.update = new ns.Update(this.view, ns.layout.page('syncLayout', {}), {});
+                this.update.render()
+                    .then(function() {
+                        done();
+                    });
+
+                this.sinon.server.requests[0].respond(200, {"Content-Type": "application/json"}, this.response0);
+            });
+
+            it('should make valid all related models', function() {
+                expect(ns.Model.get('mSync1').isValid()).to.be.ok;
+                expect(ns.Model.get('mSync2').isValid()).to.be.ok;
+                expect(ns.Model.get('mSync3').isValid()).to.be.ok;
+            });
+
+            it('should create correctly nested nodes of views', function() {
+                expect(this.view.$node.find('.ns-view-vSync0').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync0 .ns-view-vSync1').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync0 .ns-view-vSync2').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync3').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync4').length).to.equal(1);
+            });
+
+            it('should call perf once', function() {
+                expect(ns.Update.prototype.perf).to.have.been.calledOnce;
+            });
+
+            it('should have had profiled stages `collectModels`, `requestSyncModels`, `collectViews`, `generateHTML`, `insertNodes`, `triggerEvents`', function() {
+                var arg = ns.Update.prototype.perf.getCall(0).args[0];
+                expect(arg).to.have.property('collectModels').that.is.at.least(0);
+                expect(arg).to.have.property('requestSyncModels').that.is.at.least(0);
+                expect(arg).to.have.property('collectViews').that.is.at.least(0);
+                expect(arg).to.have.property('generateHTML').that.is.at.least(0);
+                expect(arg).to.have.property('insertNodes').that.is.at.least(0);
+                expect(arg).to.have.property('triggerEvents').that.is.at.least(0);
+            });
         });
 
+        describe('render (async layout)', function() {
+            beforeEach(function(done) {
+                this.modelsMethod = sinon.spy(ns.request, 'models');
+
+                this.update = new ns.Update(this.view, ns.layout.page('asyncLayout', {}), {});
+                this.update.render().then(function(result) {
+                    result.async[0].then(function() {
+                        result.async[1].then(function() {
+                            done();
+                        }, this);
+                        this.sinon.server.requests[2].respond(200, {"Content-Type": "application/json"}, this.response2);
+                    }, this);
+                    this.sinon.server.requests[1].respond(200, {"Content-Type": "application/json"}, this.response1);
+                }, this);
+
+                this.sinon.server.requests[0].respond(200, {"Content-Type": "application/json"}, this.response0);
+            });
+
+            afterEach(function() {
+                this.modelsMethod.restore();
+            });
+
+            it('should request models of sync views before models of async views', function() {
+                var modelsFirst = ns.request.models.firstCall.args[0];
+                var modelsSecond = ns.request.models.secondCall.args[0];
+                var modelsThird = ns.request.models.thirdCall.args[0];
+
+                expect(modelsFirst[0]).to.equal(ns.Model.get('mSync1'));
+                expect(modelsFirst[1]).to.equal(ns.Model.get('mSync2'));
+                expect(modelsFirst[2]).to.equal(ns.Model.get('mSync3'));
+
+                expect(modelsSecond[0]).to.equal(ns.Model.get('mAsync1'));
+                expect(modelsThird[0]).to.equal(ns.Model.get('mAsync2'));
+            });
+
+            it('should make all models of sync views valid', function() {
+                expect(ns.Model.get('mSync1').isValid()).to.be.ok;
+                expect(ns.Model.get('mSync2').isValid()).to.be.ok;
+                expect(ns.Model.get('mSync3').isValid()).to.be.ok;
+            });
+
+            it('should make all models of async views valid', function() {
+                expect(ns.Model.get('mAsync1').isValid()).to.be.ok;
+                expect(ns.Model.get('mAsync2').isValid()).to.be.ok;
+            });
+
+            it('should create correctly nested nodes of sync views', function() {
+                expect(this.view.$node.find('.ns-view-vSync0').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync0 .ns-view-vSync1').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync0 .ns-view-vSync2').length).to.equal(1);
+            });
+
+            it('should create nodes of async views', function() {
+                expect(this.view.$node.find('.ns-view-vAsync1').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vAsync2').length).to.equal(1);
+            });
+
+            it('should create nodes of async views descendants', function() {
+
+                // FIXME: в ns.View нужно распиливать метод _tryPushToRequest на 2 части:
+                // 1. _updateAsyncState
+                // 2. _tryPushToRequest
+
+                // Пока кажется, что это распилить можно только вынесением рекурсивных
+                // обходов из ns.View в ns.Update.
+                // Аргументы за:
+                // 1. Это необходимо для того, чтобы не вызывать _getRequestViews в сценарии rerender
+                // 2. Это необходимо для нового сценария applyHTML (название скорее всего изменится)
+
+                expect(this.view.$node.find('.ns-view-vSync3').length).to.equal(1);
+                expect(this.view.$node.find('.ns-view-vSync4').length).to.equal(1);
+            });
+
+            it('should call perf three times', function() {
+                expect(ns.Update.prototype.perf).to.have.been.calledThrise;
+            });
+
+            it('should have had profiled stages `collectModels`, `requestSyncModels`, `collectViews`, `generateHTML`, `insertNodes`, `triggerEvents` of first update', function() {
+                var arg = ns.Update.prototype.perf.getCall(0).args[0];
+                expect(arg).to.have.property('collectModels').that.is.at.least(0);
+                expect(arg).to.have.property('requestSyncModels').that.is.at.least(0);
+                expect(arg).to.have.property('collectViews').that.is.at.least(0);
+                expect(arg).to.have.property('generateHTML').that.is.at.least(0);
+                expect(arg).to.have.property('insertNodes').that.is.at.least(0);
+                expect(arg).to.have.property('triggerEvents').that.is.at.least(0);
+            });
+
+            it('should have had profiled stages `collectViews`, `generateHTML`, `insertNodes`, `triggerEvents` of second update', function() {
+                var arg = ns.Update.prototype.perf.getCall(1).args[0];
+
+                expect(arg).to.have.property('collectViews').that.is.at.least(0);
+                expect(arg).to.have.property('generateHTML').that.is.at.least(0);
+                expect(arg).to.have.property('insertNodes').that.is.at.least(0);
+                expect(arg).to.have.property('triggerEvents').that.is.at.least(0);
+            });
+
+            it('should have had profiled stages `collectViews`, `generateHTML`, `insertNodes`, `triggerEvents` of third update', function() {
+                var arg = ns.Update.prototype.perf.getCall(2).args[0];
+
+                expect(arg).to.have.property('collectViews').that.is.at.least(0);
+                expect(arg).to.have.property('generateHTML').that.is.at.least(0);
+                expect(arg).to.have.property('insertNodes').that.is.at.least(0);
+                expect(arg).to.have.property('triggerEvents').that.is.at.least(0);
+            });
+        });
     });
 
     describe('concurent ns.Update instances', function() {
@@ -379,7 +617,8 @@ describe('no.Updater', function() {
                     try {
                         expect(data).to.be.eql({
                             error: ns.U.STATUS.MODELS,
-                            models: [ns.Model.get('model')]
+                            invalidModels: [ns.Model.get('model')],
+                            validModels: []
                         });
                         finish();
                     } catch(e) {
@@ -459,7 +698,7 @@ describe('no.Updater', function() {
                     data.async[0].fail(function(result) {
                         try {
                             expect(result).to.have.property('error', ns.U.STATUS.MODELS);
-                            expect(result.models).to.be.eql([ns.Model.get('model')]);
+                            expect(result.invalidModels).to.be.eql([ns.Model.get('model')]);
                             finish();
                         } catch(e) {
                             finish(e);
@@ -502,7 +741,7 @@ describe('no.Updater', function() {
             });
         });
 
-        it('check arg to ns.tmpl', function() {
+        it('check arg to ns.renderString', function() {
             var renderJSON = {
                 'views': {
                     'main': {
@@ -532,7 +771,7 @@ describe('no.Updater', function() {
                     }
                 }
             };
-            expect(ns.tmpl.calledWithMatch(renderJSON)).to.be.equal(true);
+            expect(ns.renderString.calledWithMatch(renderJSON)).to.be.equal(true);
         });
     });
 

--- a/test/spec/ns.view.errors.js
+++ b/test/spec/ns.view.errors.js
@@ -72,7 +72,7 @@ describe('ns.View error handling', function() {
                         }
                     }
                 };
-                expect(ns.tmpl.calledWithMatch(renderJSON)).to.be.equal(true);
+                expect(ns.renderString.calledWithMatch(renderJSON)).to.be.equal(true);
                 finish();
             });
         });
@@ -87,7 +87,7 @@ describe('ns.View error handling', function() {
         });
     });
 
-    describe('async view is redrawn in case model with error for sync view is handled by ns.Update.handleError', function() {
+    describe('async view is redrawn in case of model with error for sync view is handled by ns.Update.handleError', function() {
         var setupServerResponses = function(that, modelResponses) {
             var responses = {};
             for (var model_id in modelResponses) {
@@ -146,11 +146,9 @@ describe('ns.View error handling', function() {
 
             promise
                 .then(function(details) {
-                    Vow.all(details.async)
-                        .done(function() { done(); })
-                        .fail(function() { done(); });
-                }, function() {
-                    done();
+                    Vow.all(details.async).always(function() {
+                        done();
+                    });
                 });
         });
 

--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -536,12 +536,12 @@ describe('ns.View', function() {
         });
 
         it('в дерево отрисовки вида должны попасть добавленный свойства', function() {
-            var renderTree = ns.tmpl.getCall(0).args[0];
+            var renderTree = ns.renderString.getCall(0).args[0];
             renderTree.views.tst.should.have.property('prop', 'foo');
         });
 
         it('в дерево отрисовки вида не должны попасть свойства, перетирающие стандартные', function() {
-            var renderTree = ns.tmpl.getCall(0).args[0];
+            var renderTree = ns.renderString.getCall(0).args[0];
             renderTree.views.tst.should.not.have.property('key', 'foo');
         });
 

--- a/test/stub/global.js
+++ b/test/stub/global.js
@@ -3,7 +3,8 @@ beforeEach(function() {
         useFakeServer: true
     });
 
-    this.sinon.spy(ns, 'tmpl');
+    this.sinon.spy(ns, 'renderString');
+    this.sinon.spy(ns, 'renderNode');
     this.sinon.stub(ns.history, 'pushState');
     this.sinon.stub(ns.history, 'replaceState');
 });


### PR DESCRIPTION
Не мерджить!

Этот pr сделан для обсуждения моего видения api ns.update для решения задач
- рендеринг на сервере
- предзагрузка моделей
- prerender видов

Основное отличие состоит в том, что вместо запуска ns.update с определёнными опциями, которые кастомизируют единый сложный алгоритм обновления, я предлагаю вызывать отдельные методы, которые при выполнении комбинируют стратегию обновления из отдельных стадий.

Я вижу в нём следующие преимущества
- большая гибкость кода. Добавление новых стратегий обновления будет сводиться к добавлению стадий и создания последовательности (вместо того, чтобы объять необъятный ns.update и навтыкать на него проверок новых флагов). Маленький бонус: кажется, мы можем отказаться от попытки запроса моделей при асинхронном update, т.к. он там по сути не нужен.
- объективно большая прозрачность кода. Короткие методы, отвечающие за одно неделимое действие читать всегда проще
- более прозрачный внешний api ns.update

Ваши мнения, коллеги?
