### PR TITLE
ns.Model._clear

### DIFF
--- a/src/ns.model.js
+++ b/src/ns.model.js
@@ -567,6 +567,16 @@
     };
 
     /**
+     * Удаляет экземпляры моделей
+     * @private
+     */
+    ns.Model._clear = function() {
+        for (var id in _infos) {
+            _cache[id] = {};
+        }
+    };
+
+    /**
      * Returns model's info
      * @param {string} id Model ID.
      * @returns {object}

--- a/test/spec/ns.model.js
+++ b/test/spec/ns.model.js
@@ -308,6 +308,24 @@ describe('ns.Model', function() {
 
         });
 
+        describe('_clear', function() {
+
+            beforeEach(function() {
+                var m = ns.Model.get('m0');
+                m.setData({foo: 'bar'});
+                ns.Model._clear();
+            });
+
+            it('should remove instances', function() {
+                expect(ns.Model.getValid('m0')).not.to.be.ok;
+            });
+
+            it('should keep models defined', function() {
+                expect(ns.Model.get('m0')).to.be.ok; // shouldn`t throw
+            });
+
+        });
+
     });
 
     describe('prototype', function() {


### PR DESCRIPTION
Предлагаю вернуть обратно `ns.Model._clear` (раньше был `ns.Model._clearCaches`). Понял, что это мне необходимо для тестов моего приложения. Хочется просто после каждого теста очищать все кеши, но не убивать при этом декларации сущностей, как это делает `ns._reset`.
