### PR TITLE
метод bindModel модели-коллекции сделал публичным

### DIFF
--- a/src/ns.modelCollection.js
+++ b/src/ns.modelCollection.js
@@ -121,32 +121,42 @@
      */
     ns.ModelCollection.prototype._subscribeSplit = function(model) {
         var that = this;
-        var events = (this._modelsEvents[model.key] || (this._modelsEvents[model.key] = {}));
 
-        this._bindModel(model, 'ns-model-changed', events, function(evt, jpath) {
+        this.bindModel(model, 'ns-model-changed', function(evt, jpath) {
             that.onItemChanged(evt, model, jpath);
         });
 
-        this._bindModel(model, 'ns-model-touched', events, function(evt) {
+        this.bindModel(model, 'ns-model-touched', function(evt) {
             that.onItemTouched(evt, model);
         });
 
-        this._bindModel(model, 'ns-model-destroyed', events, function(evt) {
+        this.bindModel(model, 'ns-model-destroyed', function(evt) {
             that.onItemDestroyed(evt, model);
         });
     };
 
     /**
+     * Подписывает callback на событие eventName модели model
      *
      * @param {ns.Model} model
      * @param {string} eventName
-     * @param {object} events
      * @param {function} callback
-     * @private
      */
-    ns.ModelCollection.prototype._bindModel = function(model, eventName, events, callback) {
+    ns.ModelCollection.prototype.bindModel = function(model, eventName, callback) {
+        var events = (this._modelsEvents[model.key] || (this._modelsEvents[model.key] = {}));
+
         model.on(eventName, callback);
         events[eventName] = callback;
+    };
+
+    ns.ModelCollection.prototype.unbindModel = function(model, eventName) {
+        var events = this._modelsEvents[model.key];
+        if (!events || !events[eventName]) {
+            return;
+        }
+
+        model.off(eventName, events[eventName]);
+        delete events[eventName];
     };
 
     /**

--- a/test/spec/ns.modelCollection.js
+++ b/test/spec/ns.modelCollection.js
@@ -76,6 +76,35 @@ describe('ns.ModelCollection', function() {
 
     describe('prototype', function() {
 
+        describe('bindModel', function() {
+
+            beforeEach(function() {
+                ns.Model.define('someCollection', {
+                    isCollection: true
+                });
+                ns.Model.define('someModel');
+
+                var collection = ns.Model.get('someCollection').setData({foo: 'bar'});
+                var someModel = ns.Model.get('someModel').setData({foo: 'bar'});
+                this.callbackEvent0 = sinon.spy();
+
+                collection.bindModel(someModel, 'event0', this.callbackEvent0);
+
+                someModel.trigger('event0');
+                someModel.trigger('event0');
+                someModel.trigger('event1');
+
+                collection.unbindModel(someModel, 'event0', this.callbackEvent0);
+
+                someModel.trigger('event0');
+            });
+
+            it('should run callback only when was binded', function() {
+                expect(this.callbackEvent0.calledTwice).to.be.ok;
+            });
+
+        });
+
         describe('setData', function() {
 
             beforeEach(function() {


### PR DESCRIPTION
После next события моделей-элементов коллекции перестали всплывать до коллекции.
Теперь подписывать приходится руками и `bindModel` оказался очень полезным хелпером, как и обратный `unbindModel`. Предлагаю сделать эти методы публичными
