### PR TITLE
[ns.page] Удалить ns.transaction

### DIFF
--- a/src/ns.js
+++ b/src/ns.js
@@ -107,20 +107,6 @@ ns.initMainView = function() {
 };
 
 /**
- * Создает транзакцию (cb) и блокирует вызов ns.page.go
- * @param {Function} cb
- */
-ns.transaction = function(cb) {
-    // останавливаем ns.page.go
-    ns.page._stop = true;
-    cb();
-
-    // запускаем ns.page.go
-    ns.page._stop = false;
-    ns.page.go(ns.page._lastUrl);
-};
-
-/**
  * Выполняет проверку, что первый аргумент истиннен.
  * Если это не так - кидает ошибку.
  * @param {?} truthy Любое значение, которое проверяется на истинность.

--- a/src/ns.page.js
+++ b/src/ns.page.js
@@ -19,20 +19,6 @@
     ns.page.currentUrl = null;
 
     /**
-     *
-     * @type {boolean}
-     * @private
-     */
-    ns.page._stop = false;
-
-    /**
-     *
-     * @type {string}
-     * @private
-     */
-    ns.page._lastUrl = '';
-
-    /**
      * Осуществляем переход по ссылке.
      * @param {string} [url=ns.page.getCurrentUrl()]
      * @param {string} [action='push'] Добавить, заменить ('replace') запись, не модифицировать ('preserve') историю браузера.
@@ -43,12 +29,6 @@
             action = 'push';
         } else if (action === true) {
             action = 'replace';
-        }
-
-        if (ns.page._stop) {
-            ns.page._lastUrl = url;
-
-            return Vow.reject('transaction');
         }
 
         url = url || ns.page.getCurrentUrl();


### PR DESCRIPTION
Этот метод появился как заглушка для автоматического ns.Update при изменении моделей, чтобы можно было поменять много, а сработало только обновление.

У нас давно такого нет. Так что предлагаю его выпилить и все его ошметки.
#293
