### PR TITLE
Добавил события ns-page-after-load и ns-page-error-load

### DIFF
--- a/src/ns.page.js
+++ b/src/ns.page.js
@@ -162,7 +162,7 @@
         ns.events.trigger('ns-page-error-load', err);
 
         // proxy reject value
-        return err;
+        return Vow.reject(err);
     }
 
 })();

--- a/test/spec/ns.page.js
+++ b/test/spec/ns.page.js
@@ -46,40 +46,117 @@ describe('ns.page', function() {
                 ns.router.init();
 
                 this.sinon.stub(ns.page, 'title');
-                this.sinon.stub(ns, 'Update', function() {
-                    return {
-                        start: function() {
-                            return new Vow.Promise();
-                        }
-                    };
+            });
+
+            describe('event ns.page#ns-page-before-load', function() {
+
+                beforeEach(function() {
+                    this.sinon.stub(ns, 'Update', function() {
+                        return {
+                            start: function() {
+                                return new Vow.Promise();
+                            }
+                        };
+                    });
                 });
+
+                it('should trigger ns-page-before-load event', function() {
+                    var spy = this.sinon.spy();
+                    ns.events.on('ns-page-before-load', spy);
+                    ns.page.go('/inbox');
+
+                    expect(spy.calledOnce).to.be.equal(true);
+                    expect(spy.firstCall.args[0]).to.be.equal('ns-page-before-load');
+                    expect(spy.firstCall.args[1]).to.be.eql([ {}, { page: 'inbox', params: {}, layout: ns.layout.page('inbox', {}) } ]);
+                    expect(spy.firstCall.args[2]).to.be.equal('/inbox');
+                });
+
+                it('should trigger ns-page-before-load with old and new pages', function() {
+                    var spy = this.sinon.spy();
+                    ns.events.on('ns-page-before-load', spy);
+                    ns.page.go('/inbox');
+                    ns.page.go('/message/1');
+
+                    expect(spy.calledTwice).to.be.equal(true);
+                    expect(spy.secondCall.args[0]).to.be.equal('ns-page-before-load');
+                    expect(spy.secondCall.args[1]).to.be.eql([
+                        { page: 'inbox', params: {}, layout: ns.layout.page('inbox', {}) },
+                        { page: 'message', params: { id: '1' }, layout: ns.layout.page('message', { id: '1' }) }
+                    ]);
+                    expect(spy.secondCall.args[2]).to.be.equal('/message/1');
+                });
+
+
             });
 
-            it('should trigger ns-page-before-load event', function() {
-                var spy = this.sinon.spy();
-                ns.events.on('ns-page-before-load', spy);
-                ns.page.go('/inbox');
+            describe('event ns.page#ns-page-after-load', function() {
 
-                expect(spy.calledOnce).to.be.equal(true);
-                expect(spy.firstCall.args[0]).to.be.equal('ns-page-before-load');
-                expect(spy.firstCall.args[1]).to.be.eql([ {}, { page: 'inbox', params: {}, layout: ns.layout.page('inbox', {}) } ]);
-                expect(spy.firstCall.args[2]).to.be.equal('/inbox');
+                beforeEach(function(done) {
+                    this.sinon.stub(ns, 'Update', function() {
+                        return {
+                            start: function() {
+                                return Vow.fulfill('fulfilled');
+                            }
+                        };
+                    });
+
+                    this.spy = this.sinon.spy();
+                    ns.events.on('ns-page-after-load', this.spy);
+                    ns.page.go('/inbox')
+                        .then(function(){
+                            done();
+                        });
+                });
+
+                afterEach(function() {
+                    delete this.promise;
+                    delete this.spy;
+                });
+
+                it('should trigger ns-page-after-load', function() {
+                    expect(this.spy).to.have.callCount(1);
+                });
+
+                it('should trigger with promise fulfilled value', function() {
+                    expect(this.spy).have.been.calledWith('ns-page-after-load', 'fulfilled');
+                });
+
             });
 
-            it('should trigger ns-page-before-load with old and new pages', function() {
-                var spy = this.sinon.spy();
-                ns.events.on('ns-page-before-load', spy);
-                ns.page.go('/inbox');
-                ns.page.go('/message/1');
+            describe('event ns.page#ns-page-error-load', function() {
 
-                expect(spy.calledTwice).to.be.equal(true);
-                expect(spy.secondCall.args[0]).to.be.equal('ns-page-before-load');
-                expect(spy.secondCall.args[1]).to.be.eql([
-                    { page: 'inbox', params: {}, layout: ns.layout.page('inbox', {}) },
-                    { page: 'message', params: { id: '1' }, layout: ns.layout.page('message', { id: '1' }) }
-                ]);
-                expect(spy.secondCall.args[2]).to.be.equal('/message/1');
+                beforeEach(function(done) {
+                    this.sinon.stub(ns, 'Update', function() {
+                        return {
+                            start: function() {
+                                return Vow.reject('rejected');
+                            }
+                        };
+                    });
+
+                    this.spy = this.sinon.spy();
+                    ns.events.on('ns-page-error-load', this.spy);
+                    ns.page.go('/inbox')
+                        .then(null, function(){
+                            done();
+                        });
+                });
+
+                afterEach(function() {
+                    delete this.promise;
+                    delete this.spy;
+                });
+
+                it('should trigger ns-page-error-load', function() {
+                    expect(this.spy).to.have.callCount(1);
+                });
+
+                it('should trigger with promise rejected value', function() {
+                    expect(this.spy).have.been.calledWith('ns-page-error-load', 'rejected');
+                });
+
             });
+
 
         });
 


### PR DESCRIPTION
История: у нас есть некоторая логика на факт отрисовки страницы, для этого мне нужно такое события.

А в общем виде я тут сделал две вещи:
1. Для консистентности к `before-load`, добавил `after-load` (реакция на fullfill)
2. Если `update` не завершился, это не пройдет бесследно, а будет событие `error-load` (реакция на reject)
