### PR TITLE
fix JSDoc @returns -> @return

### DIFF
--- a/src/ns.action.js
+++ b/src/ns.action.js
@@ -57,7 +57,7 @@
      * @param {object} [params] Params
      * @param {Element} [node]
      * @param {Event} [event]
-     * @returns {*}
+     * @return {*}
      */
     ns.action.run = function(id, params, node, event) {
         var action = _actions[id];
@@ -73,7 +73,7 @@
     /**
      * Получает параметры экшена из ноды
      * @param {Node} node
-     * @returns {object}
+     * @return {object}
      */
     ns.action.getParams = function(node) {
         var paramString = node.getAttribute('data-params');
@@ -174,7 +174,7 @@
     /**
      * Process "click" event
      * @param {jQuery.Event} e
-     * @returns {boolean}
+     * @return {boolean}
      * @private
      */
     ns.action._process = function(e) {

--- a/src/ns.box.js
+++ b/src/ns.box.js
@@ -24,7 +24,7 @@ ns.Box = function(id, params) {
  *
  * @param {string} id
  * @param {object} params
- * @returns {ns.View}
+ * @return {ns.View}
  * @private
  */
 ns.Box.prototype._getView = function(id, params) {
@@ -37,7 +37,7 @@ ns.Box.prototype._getView = function(id, params) {
  * @param {string} id
  * @param {object} params
  * @param {ns.L} type
- * @returns {ns.View}
+ * @return {ns.View}
  * @private
  */
 ns.Box.prototype._addView = function(id, params, type) {
@@ -56,7 +56,7 @@ ns.Box.prototype._addView = function(id, params, type) {
 /**
  *
  * @param {array} descs
- * @returns {array}
+ * @return {array}
  * @private
  */
 ns.Box.prototype._getDescendants = function(descs) {
@@ -115,7 +115,7 @@ ns.Box.prototype._getUpdateTree = function(tree, layout, params) {
  * Строим дерево блоков.
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.Box.prototype._getViewTree = function(layout, params) {
@@ -240,7 +240,7 @@ ns.Box.prototype._updateHTML = function(node, layout, params, options, events) {
 
 /**
  *
- * @returns {boolean}
+ * @return {boolean}
  * @private
  */
 ns.Box.prototype._show = function() {
@@ -255,7 +255,7 @@ ns.Box.prototype._show = function() {
 
 /**
  * Скрывает view
- * @returns {Boolean}
+ * @return {Boolean}
  * @protected
  */
 ns.Box.prototype._hide = function() {
@@ -288,7 +288,7 @@ ns.Box.prototype.isLoading = no.false;
 
 /**
  * Returns true if box has status NONE
- * @returns {boolean}
+ * @return {boolean}
  */
 ns.Box.prototype.isNone = function() {
     return !this.node;

--- a/src/ns.dom.js
+++ b/src/ns.dom.js
@@ -21,7 +21,7 @@ ns.removeNode = function(node) {
 /**
  * Generates DOM from HTML-string.
  * @param {string} html
- * @returns {Element}
+ * @return {Element}
  */
 ns.html2node = function(html) {
     var div = document.createElement('div');
@@ -36,7 +36,7 @@ ns.html2node = function(html) {
  * @name ns.byClass
  * @param {string} className
  * @param {Element} context
- * @returns {Node[]}
+ * @return {Node[]}
  */
 if ((typeof document !== 'undefined') && document.getElementsByClassName) {
 

--- a/src/ns.entityify.js
+++ b/src/ns.entityify.js
@@ -21,7 +21,7 @@
     /**
      * Преобразует специальные символы в HTML сущности.
      * @param {string} s Строка
-     * @returns {string}
+     * @return {string}
      */
     ns.entityify = function(s) {
         return String(s).replace(ENTITYIFY_REGEXP, ENTITYIFY_REPLACER);
@@ -49,7 +49,7 @@
     /**
      * Преобразует HTML-сущности в символы.
      * @param {string} s Строка
-     * @returns {string}
+     * @return {string}
      */
     ns.deentityify = function(s) {
         return String(s).replace(DEENTITYIFY_REGEXP, DEENTITYIFY_REPLACER);

--- a/src/ns.history.js
+++ b/src/ns.history.js
@@ -52,7 +52,7 @@
     /**
      * Проверяет, является ли переданный объект функцией.
      * @param  {Function} fn
-     * @returns {Boolean}
+     * @return {Boolean}
      */
     function isFunction(fn) {
         return 'function' === typeof fn;

--- a/src/ns.http.js
+++ b/src/ns.http.js
@@ -3,7 +3,7 @@
  * @param {string} url
  * @param {object} params Request parameters.
  * @param {object=} options Standart jQuery.ajax settings object.
- * @returns {Vow.Promise}
+ * @return {Vow.Promise}
  */
 ns.http = function(url, params, options) {
     options = no.extend(ns.http.DEFAULTS, options || {});

--- a/src/ns.js
+++ b/src/ns.js
@@ -35,7 +35,7 @@ ns.todo = function() {
 /**
  * Parse query string to object.
  * @param {string} s Query string
- * @returns {object}
+ * @return {object}
  */
 ns.parseQuery = function(s) {
     var o = {};
@@ -74,7 +74,7 @@ ns.parseQuery = function(s) {
  * @param {*} json
  * @param {string} mode
  * @param {string} [module='main']
- * @returns {Element}
+ * @return {Element}
  */
 ns.tmpl = function(json, mode, module) {
     var result = yr.run(module || 'main', json, mode);
@@ -137,7 +137,7 @@ ns.assert.fail = function(contextName, message) {
  * Строит ключ по готовому объекту параметров.
  * @param {string} prefix Префикс ключа.
  * @param {object} params Объект с параметрами составляющими ключ.
- * @returns {string} Строка ключа.
+ * @return {string} Строка ключа.
  */
 ns.key = function(prefix, params) {
     var key = prefix;

--- a/src/ns.layout.js
+++ b/src/ns.layout.js
@@ -41,7 +41,7 @@
      * Возвращает раскладку страницы с заданным id и params.
      * @param {string} id ID раскладки
      * @param {object} [params] Параметры страницы.
-     * @returns {object}
+     * @return {object}
      */
     ns.layout.page = function(id, params) {
         var raw = _pages[id];
@@ -65,7 +65,7 @@
      * Интерполируем ключи, раскрываем шоткаты, вычисляем функции и т.д.
      * @param {*} layout
      * @param {object} params
-     * @returns {object}
+     * @return {object}
      */
     function compile(layout, params) {
         var t = {};
@@ -135,7 +135,7 @@
      * Наследует layout от parent'а.
      * @param {object} layout
      * @param {object} parent
-     * @returns {object}
+     * @return {object}
      */
     function inherit(layout, parent) {
         var result = ns.object.clone(parent);

--- a/src/ns.model.js
+++ b/src/ns.model.js
@@ -130,7 +130,7 @@
      * Ищет метод в объекте по имени или возвращает переданную функцию
      * Нужен для навешивания коллбеков
      * @param {String | Function} method
-     * @returns {Function}
+     * @return {Function}
      * @private
      */
     ns.Model.prototype._prepareCallback = function(method) {
@@ -161,7 +161,7 @@
 
     /**
      *
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.Model.prototype.isValid = function() {
         return (this.status === this.STATUS.OK);
@@ -169,7 +169,7 @@
 
     /**
      *
-     * @returns {null|*}
+     * @return {null|*}
      */
     ns.Model.prototype.getData = function() {
         return this.data;
@@ -178,7 +178,7 @@
     /**
      * Returns data matched by jpath.
      * @param {string} jpath
-     * @returns {*}
+     * @return {*}
      * @example
      * var foo = model.get('.foo'); // model.data.foo.
      * var bar = model.get('.foo.bar'); // model.data.foo.bar (если foo существует).
@@ -194,7 +194,7 @@
      * Returns data matched by jpath.
      * This methods always returns array of results.
      * @param {string} jpath
-     * @returns {array}
+     * @return {array}
      */
     ns.Model.prototype.select = function(jpath) {
         var data = this.data;
@@ -252,7 +252,7 @@
      * @param {*} data Новые данные.
      * @param {object} [options] Флаги.
      * @param {Boolean} [options.silent = false] Если true, то не генерируется событие о том, что модель изменилась.
-     * @returns {ns.Model}
+     * @return {ns.Model}
      */
     ns.Model.prototype.setData = function(data, options) {
         // переинициализация после #destroy()
@@ -283,7 +283,7 @@
     /**
      *
      * @param {*} data
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.Model.prototype.hasDataChanged = function(data) {
         return !!data;
@@ -291,7 +291,7 @@
 
     /**
      *
-     * @returns {*}
+     * @return {*}
      */
     ns.Model.prototype.getError = function() {
         return this.error;
@@ -310,7 +310,7 @@
     /**
      *
      * @param {*} data
-     * @returns {*}
+     * @return {*}
      * @private
      */
     ns.Model.prototype._beforeSetData = function(data) {
@@ -320,7 +320,7 @@
     /**
      *
      * @param {*} data
-     * @returns {*}
+     * @return {*}
      */
     ns.Model.prototype.preprocessData = function(data) {
         return data;
@@ -328,7 +328,7 @@
 
     /**
      *
-     * @returns {object}
+     * @return {object}
      */
     ns.Model.prototype.getRequestParams = function() {
         return ns.Model._getKeyParams(this.id, this.params, this.info);
@@ -336,7 +336,7 @@
 
     /**
      * Возвращает, можно ли перезапрашивать эту модель, если предыдущий запрос не удался.
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.Model.prototype.canRetry = function() {
         //  do-модели нельзя перезапрашивать.
@@ -346,7 +346,7 @@
     /**
      *
      * @param {*} result
-     * @returns {*}
+     * @return {*}
      */
     ns.Model.prototype.extractData = function(result) {
         if (result) {
@@ -357,7 +357,7 @@
     /**
      *
      * @param {*} result
-     * @returns {*}
+     * @return {*}
      */
     ns.Model.prototype.extractError = function(result) {
         if (result) {
@@ -367,7 +367,7 @@
 
     /**
      *
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.Model.prototype.isDo = function() {
         return this.info.isDo;
@@ -375,7 +375,7 @@
 
     /**
      * Returns data version.
-     * @returns {number}
+     * @return {number}
      */
     ns.Model.prototype.getVersion = function() {
         return this._version;
@@ -392,7 +392,7 @@
     /**
      * Подготавливает модель к запросу.
      * @param {number} requestID ID запроса.
-     * @returns {ns.Model}
+     * @return {ns.Model}
      */
     ns.Model.prototype.prepareRequest = function(requestID) {
         this.requestID = requestID;
@@ -415,7 +415,7 @@
      * @static
      * @param {string} id Model's ID.
      * @param {object} [params] Model's params.
-     * @returns {ns.Model}
+     * @return {ns.Model}
      */
     ns.Model.get = function(id, params) {
         var model = this._find(id, params);
@@ -440,7 +440,7 @@
      * Returns valid cached model instance.
      * @param {string} id Model's ID.
      * @param {object} [params] Model's params
-     * @returns {ns.Model|null}
+     * @return {ns.Model|null}
      */
     ns.Model.getValid = function(id, params) {
         var model = this._find(id, params);
@@ -454,7 +454,7 @@
      * Returns cached model instance.
      * @param {string} id Model's ID.
      * @param {object} [params] Model's params
-     * @returns {ns.Model|null}
+     * @return {ns.Model|null}
      * @private
      */
     ns.Model._find = function(id, params) {
@@ -489,7 +489,7 @@
      *
      * @param {string} id
      * @param {object} params
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.Model.isValid = function(id, params) {
         return !!ns.Model.getValid(id, params);
@@ -579,7 +579,7 @@
     /**
      * Returns model's info
      * @param {string} id Model ID.
-     * @returns {object}
+     * @return {object}
      * @throws Throws exception if model is not defined.
      */
     ns.Model.info = function(id) {
@@ -613,7 +613,7 @@
     /**
      * Returns model's info without processing.
      * @param {string} id Model ID.
-     * @returns {object}
+     * @return {object}
      */
     ns.Model.infoLite = function(id) {
         var info = _infos[id];
@@ -627,7 +627,7 @@
      * @param {string} id
      * @param {object} params
      * @param {object} info
-     * @returns {string}
+     * @return {string}
      */
     ns.Model.key = function(id, params, info) {
         info = info || ns.Model.info(id);
@@ -649,7 +649,7 @@
      * @param {string} id
      * @param {object} params
      * @param {object} info
-     * @returns {*}
+     * @return {*}
      * @private
      */
     ns.Model._getKeyParams = function(id, params, info) {
@@ -726,7 +726,7 @@
     /**
      *
      * @param {ns.Model} model
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.Model.isCollection = function(model) {
         return (model.info || ns.Model.infoLite(model.id)).isCollection;
@@ -876,7 +876,7 @@
 
     /**
      * Возвращает кэш по параметрам
-     * @returns {*}
+     * @return {*}
      */
     ns.ModelUniq.prototype.getData = function(params) {
         var that = this;

--- a/src/ns.modelCollection.js
+++ b/src/ns.modelCollection.js
@@ -24,7 +24,7 @@
 
     /**
      *
-     * @returns {{}|*}
+     * @return {{}|*}
      */
     ns.ModelCollection.prototype.getData = function() {
         // TODO а точно это нужно? Можно ведь просто всегда взять элементы из collection.models.
@@ -95,7 +95,7 @@
      * Создает модели из разбитых данных
      *
      * @param { Array } items – массив данных для будущих подмоделей
-     * @returns { ns.Model[] } – массив полученных подмоделей
+     * @return { ns.Model[] } – массив полученных подмоделей
      * @private
      */
     ns.ModelCollection.prototype._splitModels = function(items) {
@@ -195,7 +195,7 @@
 
     /**
      * Returns data version (included items version).
-     * @returns {number}
+     * @return {number}
      */
     ns.ModelCollection.prototype.getSelfVersion = function() {
         return this._versionSelf;
@@ -257,7 +257,7 @@
      * @param {ns.Model[] | ns.Model} models – одна или несколько подмоделей для вставки
      * @param {number} [index] – индекс позиции, на которую вставить подмодели. Если не передано - вставка в конец.
      *
-     * @returns {Boolean} – признак успешности вставки
+     * @return {Boolean} – признак успешности вставки
      */
     ns.ModelCollection.prototype.insert = function(models, index) {
         // переинициализация после #destroy()
@@ -303,7 +303,7 @@
      * Удаляет элементы коллекции.
      *
      * @param {ns.Model | Number | ns.Model[] | Number[]} models – подмодели или индексы подмодели, которую надо удалить
-     * @returns {Boolean} – признак успешности удаления.
+     * @return {Boolean} – признак успешности удаления.
      */
     ns.ModelCollection.prototype.remove = function(models) {
         var modelsRemoved = [];

--- a/src/ns.object.js
+++ b/src/ns.object.js
@@ -7,7 +7,7 @@ ns.object = {};
 /**
  * Клонирует объект.
  * @param {object} obj Объект для клонирования.
- * @returns {object}
+ * @return {object}
  */
 ns.object.clone = function(obj) {
     if (obj && typeof obj === 'object') {
@@ -34,7 +34,7 @@ ns.object.clone = function(obj) {
 /**
  * Определяет, пустой ли объект или нет.
  * @param {object} obj Тестируемый объект.
- * @returns {boolean}
+ * @return {boolean}
  */
 ns.object.isEmpty = function(obj) {
     /* jshint unused: false */

--- a/src/ns.page.block.js
+++ b/src/ns.page.block.js
@@ -18,7 +18,7 @@
      * @description
      * Функция блокировки должна вернуть false, если переход нельзя осуществить.
      * @param {Function} fn
-     * @returns {ns.page.block}
+     * @return {ns.page.block}
      */
     ns.page.block.add = function(fn) {
         ns.page.block._checkers.push(fn);
@@ -29,7 +29,7 @@
     /**
      * Remove function to check.
      * @param {Function} fn
-     * @returns {ns.page.block}
+     * @return {ns.page.block}
      */
     ns.page.block.remove = function(fn) {
         var checkers = ns.page.block._checkers;
@@ -43,7 +43,7 @@
 
     /**
      * Очищает все функции блокировки.
-     * @returns {ns.page.block}
+     * @return {ns.page.block}
      */
     ns.page.block.clear = function() {
         ns.page.block._checkers = [];
@@ -54,7 +54,7 @@
      * Detect if possible to go to the url.
      * You can add your own checkers with ns.page.block.add(checkerFn)
      * @param {string} url URL to go.
-     * @returns {Boolean}
+     * @return {Boolean}
      */
     ns.page.block.check = function(url) {
         var checkers = ns.page.block._checkers;

--- a/src/ns.page.history.js
+++ b/src/ns.page.history.js
@@ -49,7 +49,7 @@
 
     /**
      * Go to previous page and delete it from history.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     ns.page.history.back = function() {
         var nsHistory = ns.page.history;
@@ -73,7 +73,7 @@
     /**
      * Returns previous page.
      * @param {number} [n=0] N pages ago
-     * @returns {string}
+     * @return {string}
      */
     ns.page.history.getPrevious = function(n) {
         n = n || 0;

--- a/src/ns.page.js
+++ b/src/ns.page.js
@@ -22,7 +22,7 @@
      * Осуществляем переход по ссылке.
      * @param {string} [url=ns.page.getCurrentUrl()]
      * @param {string} [action='push'] Добавить, заменить ('replace') запись, не модифицировать ('preserve') историю браузера.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     ns.page.go = function(url, action) {
         if (!action) {
@@ -87,7 +87,7 @@
     /**
      * Redirects to given url.
      * @param {string} url New page url.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     ns.page.redirect = function(url) {
         ns.history.replaceState(url);
@@ -97,7 +97,7 @@
     /**
      * Returns document title.
      * @param {string} url Page URL.
-     * @returns {string}
+     * @return {string}
      */
     ns.page.title = function(url) {
         return 'NoScript app ' + url;

--- a/src/ns.profile.js
+++ b/src/ns.profile.js
@@ -28,7 +28,7 @@
     /**
      * Ставит конечную точку отчета для метрики.
      * @param {string} label Название метрики.
-     * @returns {number} Рассчитанное значение метрики.
+     * @return {number} Рассчитанное значение метрики.
      */
     ns.profile.stopTimer = function(label) {
         if (!this._profileTimes) {
@@ -45,7 +45,7 @@
     /**
      * Возвращает значение метрики.
      * @param {string} label Название метрики.
-     * @returns {number}
+     * @return {number}
      */
     ns.profile.getTimer = function(label) {
         if (!this._profileTimes) {

--- a/src/ns.request.js
+++ b/src/ns.request.js
@@ -10,7 +10,7 @@
      * @param {object} [params] Параметры моделей.
      * @param {object} [options] Опции запроса.
      * @param {Boolean} [options.forced=false] Не учитывать закешированность моделей при запросе.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      * @namespace
      */
     ns.request = function(items, params, options) {
@@ -24,7 +24,7 @@
      * @param {object} [params] Параметры моделей.
      * @param {object} [options] Опции запроса.
      * @param {Boolean} [options.forced=false] Не учитывать закешированность моделей при запросе.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     ns.forcedRequest = function(items, params, options) {
         options = options || {};
@@ -37,7 +37,7 @@
      * @param {ns.Model[]} models Массив моделей.
      * @param {object} [options] Опции запроса.
      * @param {Boolean} [options.forced=false] Не учитывать закешированность моделей при запросе.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     ns.request.models = function(models, options) {
 
@@ -76,7 +76,7 @@
     /**
      * Метод для проверки ответа данных.
      * Может использоваться, например, при проверки авторизации.
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.request.canProcessResponse = function() {
         return true;
@@ -108,7 +108,7 @@
          * @param {ns.Model} model Модель.
          * @param {number} requestId ID запроса.
          * @param {Boolean} forced Флаг принудительного запроса.
-         * @returns {Boolean|ns.Model} Если true - модель надо запросить, false - ничег не надо делать, ns.Model - дождаться ресолва промиса возвращенной модели.
+         * @return {Boolean|ns.Model} Если true - модель надо запросить, false - ничег не надо делать, ns.Model - дождаться ресолва промиса возвращенной модели.
          */
         add: function(model, requestId, forced) {
             var REQUEST_STATUS = this.STATUS;
@@ -418,7 +418,7 @@
      * Приводит запрашиваемые модели к формату №3 из ns.request.
      * @param {Array} items Массив названией моделей.
      * @param {object} params Параметры моделей.
-     * @returns {Array}
+     * @return {Array}
      */
     function normalizeItems(items, params) {
         var _items = [];
@@ -435,7 +435,7 @@
     /**
      * Возвращает promise из model
      * @param {ns.Model} model Модель
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     function model2Promise(model) {
         return model.promise;
@@ -445,7 +445,7 @@
      * Приводит аргументы из ns.request к моделям.
      * @param {String|Array|Object} items Массив названий моделей.
      * @param {object} [params] Параметры моделей.
-     * @returns {ns.Model[]}
+     * @return {ns.Model[]}
      */
     function items2models(items, params) {
         // приводим к формату №2

--- a/src/ns.router.js
+++ b/src/ns.router.js
@@ -2,7 +2,7 @@
  * Find best page for url.
  * @namespace
  * @param {string} url
- * @returns {object}
+ * @return {object}
  * @tutorial ns.router
  */
 ns.router = function(url) {
@@ -96,7 +96,7 @@ ns.router = function(url) {
  * Get params for router from url
  * @param {string} url - current url
  * @param {object} route - compiled route or redirect
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.router._getParamsRouteFromUrl = function(url, route) {
@@ -185,7 +185,7 @@ ns.router.init = function() {
 /**
  * Generate url.
  * @param {string} url Relative url.
- * @returns {string} Valid url that takes into consideration baseDir.
+ * @return {string} Valid url that takes into consideration baseDir.
  */
 ns.router.url = function(url) {
     return (ns.router.baseDir + url) || '/';
@@ -194,7 +194,7 @@ ns.router.url = function(url) {
 /**
  * @param {string} id Page (layout) name.
  * @param {object} params Url generation params.
- * @returns {string} Generated url.
+ * @return {string} Generated url.
  */
 ns.router.generateUrl = function(id, params) {
     var url;
@@ -219,7 +219,7 @@ ns.router.generateUrl = function(id, params) {
  *
  * @param {object} def
  * @param {object} params
- * @returns {string}
+ * @return {string}
  * @private
  */
 ns.router._generateUrl = function(def, params) {
@@ -297,7 +297,7 @@ ns.router._generateUrl = function(def, params) {
 /**
  * Compile route.
  * @param {string} route
- * @returns {object}
+ * @return {object}
  */
 ns.router.compile = function(route) {
     // Удаляем слеши в начале и в конце урла.
@@ -330,7 +330,7 @@ ns.router.compile = function(route) {
 /**
  *
  * @param {string} rawSection
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.router._parseSection = function(rawSection) {
@@ -378,7 +378,7 @@ ns.router._parseSection = function(rawSection) {
 
 /**
  * Парсит декларацию параметра (то, что внутри фигурных скобок).
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.router._parseParam = function(param) {
@@ -421,7 +421,7 @@ ns.router._parseParam = function(param) {
 /**
  *
  * @param {object} section
- * @returns {string}
+ * @return {string}
  * @private
  */
 ns.router._generateSectionRegexp = function(section) {
@@ -443,7 +443,7 @@ ns.router._generateSectionRegexp = function(section) {
 /**
  *
  * @param {object} p
- * @returns {RegExp}
+ * @return {RegExp}
  * @private
  */
 ns.router._generateParamRegexp = function(p) {
@@ -480,7 +480,7 @@ ns.router._generateParamRegexp = function(p) {
  *
  * @param {string} pvalue
  * @param {string} ptype
- * @returns {boolean}
+ * @return {boolean}
  * @private
  */
 ns.router._isParamValid = function(pvalue, ptype) {

--- a/src/ns.update.js
+++ b/src/ns.update.js
@@ -80,7 +80,7 @@
     /**
      * Начинает работу updater'а.
      * @param {boolean} [async=false] Флаг асинхронного updater'а.
-     * @returns {Vow.Promise}
+     * @return {Vow.Promise}
      */
     ns.Update.prototype.start = function(async) {
         this.startTimer('prepare');
@@ -299,7 +299,7 @@
      * @param {object} tree Дерево видов.
      * @param {object} params Параметры страницы.
      * @param {object} layout Раскладка страницы.
-     * @returns {HTMLElement}
+     * @return {HTMLElement}
      */
     ns.Update.prototype.render = function(tree, params, layout) {
         /* jshint unused: false */
@@ -307,7 +307,7 @@
     };
 
     /**
-     * @returns {Boolean} true in case another update was created after current update.
+     * @return {Boolean} true in case another update was created after current update.
      * @private
      */
     ns.Update.prototype._expired = function() {
@@ -372,7 +372,7 @@
      * @static
      * @private
      * @param {ns.Update} newUpdate New instance of ns.Update.
-     * @returns Boolean
+     * @return Boolean
      */
     ns.Update.prototype.addToQueue = function(newUpdate) {
         var currentRuns = currentUpdates;
@@ -424,7 +424,7 @@
 
     /**
      * Whether this update is a global update (main update) or not.
-     * @returns Boolean.
+     * @return Boolean.
      */
     ns.Update.prototype.isGlobal = function() {
         return this.EXEC_FLAG === ns.U.EXEC.GLOBAL;
@@ -445,7 +445,7 @@
      * Global error handler.
      * @param {object} error Error summary object `{ error: string, models: Array.<ns.Model> }`.
      * @param {ns.Update} update Update instance so that we can abort it if we want to.
-     * @returns Boolean If `true` - update can continue, otherwise update cannot continue.
+     * @return Boolean If `true` - update can continue, otherwise update cannot continue.
      */
     ns.Update.handleError = function(error, update) {
         /* jshint unused: false */

--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -125,7 +125,7 @@
     /**
      *
      * @param {string} id
-     * @returns {ns.View}
+     * @return {ns.View}
      * @private
      */
     ns.View.prototype._getView = function(id) {
@@ -137,7 +137,7 @@
      * @param {string} id
      * @param {object} params
      * @param {ns.L} type
-     * @returns {*}
+     * @return {*}
      * @private
      */
     ns.View.prototype._addView = function(id, params, type) {
@@ -176,7 +176,7 @@
     /**
      * Скрывает view
      * @param {array} [events] Массив событий.
-     * @returns {boolean}
+     * @return {boolean}
      * @protected
      */
     ns.View.prototype._hide = function(events) {
@@ -220,7 +220,7 @@
      * Показывает View
      * @param {array} [events] Массив событий.
      * @protected
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype._show = function(events) {
         // При создании блока у него this._visible === undefined.
@@ -316,7 +316,7 @@
     /**
      * Returns function or method from prototype.
      * @param {String|Function} fn Function or method name from prototype.
-     * @returns {Function}
+     * @return {Function}
      * @private
      */
     ns.View.prototype._prepareCallback = function(fn) {
@@ -333,7 +333,7 @@
      * Копирует массив деклараций событий и возвращает такой же массив, но с забинженными на этот инстанс обработчиками.
      * @param {Array} events
      * @param {number} handlerPos Позиция хендлера в массиве.
-     * @returns {Array} Копия events c забинженными обработчиками.
+     * @return {Array} Копия events c забинженными обработчиками.
      * @private
      */
     ns.View.prototype._bindEventHandlers = function(events, handlerPos) {
@@ -355,7 +355,7 @@
     /**
      * Возващает обработчики событий для View.
      * @param {string} type Тип обработчиков: 'init' или 'show'.
-     * @returns {object}
+     * @return {object}
      * @private
      */
     ns.View.prototype._getEvents = function(type) {
@@ -490,7 +490,7 @@
 
     /**
      *
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype.isOk = function() {
         return (this.status === this.STATUS.OK);
@@ -498,7 +498,7 @@
 
     /**
      *
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype.isLoading = function() {
         return (this.status === this.STATUS.LOADING);
@@ -506,7 +506,7 @@
 
     /**
      * Returns true if view has status NONE
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype.isNone = function() {
         return (this.status === this.STATUS.NONE);
@@ -514,7 +514,7 @@
 
     /**
      * Возвращает true, если блок валиден.
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype.isValid = function() {
         return this.isOk() && this.isModelsValidWithVersions();
@@ -524,13 +524,13 @@
      * Возвращает true, если блок валиден.
      * @ignore
      * @method
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype.isValidSelf = ns.View.prototype.isValid;
 
     /**
      * Returns true if models are valid and not be updated after last view update.
-     * @returns {boolean}
+     * @return {boolean}
      */
     ns.View.prototype.isModelsValidWithVersions = function() {
         return this.isModelsValid(this._modelsVersions);
@@ -539,7 +539,7 @@
     /**
      * Возвращает true, если все модели валидны.
      * @param {object} [modelsVersions] Также проверяем, что кеш модели не свежее переданной версии.
-     * @returns {Boolean}
+     * @return {Boolean}
      */
     ns.View.prototype.isModelsValid = function(modelsVersions) {
         var models = this.models;
@@ -580,7 +580,7 @@
      * @param {ns.View[]} updated.async Sync views.
      * @param {object} pageLayout Currently processing layout.
      * @param {object} params Params.
-     * @returns {object}
+     * @return {object}
      * @private
      */
     ns.View.prototype._getRequestViews = function(updated, pageLayout, params) {
@@ -666,7 +666,7 @@
 
     /**
      * Возвращает общее дерево видов.
-     * @returns {object}
+     * @return {object}
      * @private
      */
     ns.View.prototype._getTree = function() {
@@ -707,7 +707,7 @@
      * Строим дерево блоков.
      * @param {object} layout Currently processing layout.
      * @param {object} params Params.
-     * @returns {object}
+     * @return {object}
      * @private
      */
     ns.View.prototype._getViewTree = function(layout, params) {
@@ -754,7 +754,7 @@
      * }
      * ```
      * @param {object} tree Дерево наложения.
-     * @returns {object}
+     * @return {object}
      * @method
      */
     ns.View.prototype.patchTree = no.nop;
@@ -763,7 +763,7 @@
      *
      * @param {object} layout
      * @param {object} params
-     * @returns {object}
+     * @return {object}
      * @private
      */
     ns.View.prototype._getDescViewTree = function(layout, params) {
@@ -780,7 +780,7 @@
      * Возвращает декларацию вида для вставки плейсхолдера
      * @param {object} layout Currently processing layout.
      * @param {object} params Params.
-     * @returns {object}
+     * @return {object}
      * @private
      */
     ns.View.prototype._getPlaceholderTree = function(layout, params) {
@@ -793,7 +793,7 @@
 
     /**
      *
-     * @returns {*}
+     * @return {*}
      * @private
      */
     ns.View.prototype._getModelsData = function() {
@@ -813,7 +813,7 @@
 
     /**
      *
-     * @returns {*}
+     * @return {*}
      * @private
      */
     ns.View.prototype._getModelsError = function() {
@@ -833,7 +833,7 @@
     /**
      * Returns model.
      * @param {string} id Model ID
-     * @returns {ns.Model}
+     * @return {ns.Model}
      */
     ns.View.prototype.getModel = function(id) {
         return this.models[id];
@@ -842,7 +842,7 @@
     /**
      * Returns data of model.
      * @param {string} id Model ID
-     * @returns {*}
+     * @return {*}
      */
     ns.View.prototype.getModelData = function(id) {
         return this.getModel(id).getData();
@@ -853,7 +853,7 @@
      * Можно передать моду и дополнительный объект, который попадет в /.extra:
      * @param {string} mode
      * @param {object} extra
-     * @returns {HTMLElement}
+     * @return {HTMLElement}
      * @example
      * ```js
      * block.tmpl()
@@ -889,7 +889,7 @@
      * Возвращает массив всех вложенных view, включая себя
      * FIXME: это же _getDescendantsOrSelf
      * @param {Array} [views=[]] Начальный массив.
-     * @returns {Array}
+     * @return {Array}
      * @private
      */
     ns.View.prototype._getDescendants = function(views) {
@@ -932,7 +932,7 @@
     /**
      *
      * @param {HTMLElement} node
-     * @returns {HTMLElement}
+     * @return {HTMLElement}
      * @private
      */
     ns.View.prototype._extractNode = function(node) {
@@ -1099,7 +1099,7 @@
      * @param {Object|Array} [info.models] Массив или объект с моделями, от которых зависит View. Для объекта: true означает модель должна быть валидной для отрисовки view.
      * @param {object} [info.events] DOM-события, на которые подписывается View.
      * @param {Function|String} [base=ns.View] Базовый View для наследования
-     * @returns {Function} Созданный View.
+     * @return {Function} Созданный View.
      */
     ns.View.define = function(id, info, base) {
         ns.assert(!(id in _infos), 'ns.View', "Can't redefine '%s'", id);
@@ -1144,7 +1144,7 @@
     /**
      * Возвращает информацию о View.
      * @param {string} id Название модели.
-     * @returns {object}
+     * @return {object}
      * @throws Бросает исключения, если нет
      */
     ns.View.info = function(id) {
@@ -1342,7 +1342,7 @@
      * @param {string} id
      * @param {object} params
      * @param {object} [info]
-     * @returns {string}
+     * @return {string}
      */
     ns.View.getKey = function(id, params, info) {
         return this.getKeyAndParams(id, params, info).key;
@@ -1351,7 +1351,7 @@
     /**
      * Возвращает ключ объекта и параметры с учётом rewriteParamsOnInit
      * В этом методе собрана вся логика рерайтов параметров при создании view
-     * @returns {object}
+     * @return {object}
      */
     ns.View.getKeyAndParams = function(id, params, info) {
         //  Ключ можно вычислить даже для неопределенных view,
@@ -1384,7 +1384,7 @@
      * @param {string} id
      * @param {object} params
      * @param {object} info
-     * @returns {*}
+     * @return {*}
      * @private
      */
     ns.View._getKeyParams = function(id, params, info) {
@@ -1435,7 +1435,7 @@
      * @param {string} id ID view.
      * @param {object} [params] Параметры view.
      * @param {Boolean} [async=false] Может ли view бы асинхронным.
-     * @returns {ns.View}
+     * @return {ns.View}
      */
     ns.View.create = function(id, params, async) {
         var Ctor = _ctors[id];
@@ -1486,7 +1486,7 @@
      * в единый расширенный формат
      *
      * @param {object[]} decls
-     * @returns {{}}
+     * @return {{}}
      * @private
      */
     ns.View._formatModelsDecl = function(decls) {

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -16,7 +16,7 @@ no.inherit(ns.ViewCollection, ns.View);
  *
  * @param {string} id
  * @param {object} info
- * @returns {ns.View}
+ * @return {ns.View}
  */
 ns.ViewCollection.define = function(id, info) {
     info = info || {};
@@ -109,7 +109,7 @@ ns.ViewCollection.prototype._invokeModelHandler = function(handler, e, o) {
 
 /**
  *
- * @returns {boolean}
+ * @return {boolean}
  */
 ns.ViewCollection.prototype.isValid = function() {
     return this.isValidSelf() && this.isValidDesc();
@@ -117,7 +117,7 @@ ns.ViewCollection.prototype.isValid = function() {
 
 /**
  *
- * @returns {boolean}
+ * @return {boolean}
  */
 ns.ViewCollection.prototype.isValidDesc = function() {
     for (var key in this.views) {
@@ -131,7 +131,7 @@ ns.ViewCollection.prototype.isValidDesc = function() {
 /**
  * Возвращает true, если все модели валидны.
  * @param {object} [modelsVersions] Также проверяем, что кеш модели не свежее переданной версии.
- * @returns {Boolean}
+ * @return {Boolean}
  */
 ns.ViewCollection.prototype.isModelsValid = function(modelsVersions) {
     var models = this.models;
@@ -162,7 +162,7 @@ ns.ViewCollection.prototype.isModelsValid = function(modelsVersions) {
  *
  * @param {string} id
  * @param {object} params
- * @returns {*}
+ * @return {*}
  * @private
  */
 ns.ViewCollection.prototype._getView = function(id, params) {
@@ -173,7 +173,7 @@ ns.ViewCollection.prototype._getView = function(id, params) {
 /**
  *
  * @param {string} key
- * @returns {ns.View}
+ * @return {ns.View}
  * @private
  */
 ns.ViewCollection.prototype._getViewByKey = function(key) {
@@ -184,7 +184,7 @@ ns.ViewCollection.prototype._getViewByKey = function(key) {
  *
  * @param {string} id
  * @param {object} params
- * @returns {ns.View}
+ * @return {ns.View}
  * @private
  */
 ns.ViewCollection.prototype._addView = function(id, params) {
@@ -230,7 +230,7 @@ ns.ViewCollection.prototype._getRequestViews = ns.View.prototype._tryPushToReque
  * @param {object} tree
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.ViewCollection.prototype._getUpdateTree = function(tree, layout, params) {
@@ -251,7 +251,7 @@ ns.ViewCollection.prototype._getUpdateTree = function(tree, layout, params) {
  *
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
@@ -307,7 +307,7 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
  *
  * @param {object} layout
  * @param {object} params
- * @returns {object}
+ * @return {object}
  * @private
  */
 ns.ViewCollection.prototype._getViewTree = function(layout, params) {


### PR DESCRIPTION
По просьбе @chestozo заменил везде `@returns` на `@return`, чтобы привести в этом месте doc-блоки к спецификации (https://developers.google.com/closure/compiler/docs/js-for-compiler?hl=ru)
