### PR TITLE
Обратная совместимость нового yate-api ns.View

### DIFF
--- a/doc/ns.view.yate.md
+++ b/doc/ns.view.yate.md
@@ -97,8 +97,8 @@ match .my-view-collection ns-view-content {
 
 ## Yate-хелперы
 
-* `model('model-name')` - хелпер для быстрого получения данных модели. Внутри использует ключи, поэтому быстрее jpath `/.models.model-name`
-* `modelError('model-name')` - хелпер для получения ошибки модели. Внутри использует ключи, поэтому быстрее jpath `/.errors.model-name`
+* `model('model-name')` - хелпер для быстрого получения данных модели. Внутри использует ключи, поэтому быстрее, чем jpath `/.models.model-name.model-name`
+* `modelError('model-name')` - хелпер для получения ошибки модели. Внутри использует ключи, поэтому быстрее jpath `/.models.model-name.model-name`
 * `ns-url` - external-функция для `ns.router.generateUrl`
 
 ## Структура JSON для отрисовки
@@ -110,15 +110,15 @@ match .my-view-collection ns-view-content {
     key: 'view=app',
     models: {
         model1: {
-            'data': {},
+            'model1': {},
             'status': 'ok'
         },
         model2: {
-            'data': {},
+            'model2': {},
             'status': 'ok'
         },
         model3: {
-            data: 'http_timeout',
+            'model3': 'http_timeout',
             'status': 'error'
         }
     },
@@ -144,5 +144,5 @@ match .my-view-collection ns-view-content {
 **Приватные свойства**:
  - `box`: boolean. Флаг того, что это бокс.
  - `collection`: boolean. Флаг того, что это вид-коллекция.
- - `models`: object. Объект с данными моделей. Не стоит использовать его напрямую. Лучше вызывать yate-функции `model()` и `modelError()`.
+ - `models`: object. Объект с данными моделей. Не предназначен для прямого использования. Для получения моделей всегда используйте yate-хелперы `model()` и `modelError()`.
  - `state`: Текущее состояние вида. ok/error/loading/placeholder

--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -813,17 +813,17 @@
         for (var id in models) {
             /** @type ns.Model */
             var model = models[id];
+            modelsData[id] = {};
             if (model.isValid()) {
-                modelsData[id] = {
-                    data: model.getData(),
-                    status: 'ok'
-                };
-
+                // successful model status
+                modelsData[id].status = 'ok';
+                // structure for convenient matching
+                modelsData[id][id] = model.getData();
             } else {
-                modelsData[id] = {
-                    data: model.getError(),
-                    status: 'error'
-                };
+                // insuccessful model status
+                modelsData[id].status = 'error';
+                // structure for convenient matching
+                modelsData[id][id] = model.getError();
             }
         }
 

--- a/test/spec/ns.view.errors.js
+++ b/test/spec/ns.view.errors.js
@@ -65,7 +65,7 @@ describe('ns.View error handling', function() {
                                     'models': {
                                         'letter': {
                                             'status': 'error',
-                                            'data': 'letter not found'
+                                            'letter': 'letter not found'
                                         }
                                     }
                                 }
@@ -73,7 +73,7 @@ describe('ns.View error handling', function() {
                         }
                     }
                 };
-                expect(ns.renderString.calledWithMatch(renderJSON)).to.be.equal(true);
+                expect(ns.renderString.calledWithMatch(renderJSON)).to.be.ok;
                 finish();
             });
         });

--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -261,19 +261,19 @@ describe('ns.View', function() {
                     'test-view-render_complex': {
                         models: {
                             a: {
-                                data: {
+                                a: {
                                     data: 'a'
                                 },
                                 status: 'ok'
                             },
                             b: {
-                                data: {
+                                b: {
                                     error: 'b invalid'
                                 },
                                 status: 'error'
                             },
                             c: {
-                                data: {
+                                c: {
                                     error: 'c invalid'
                                 },
                                 status: 'error'

--- a/yate/noscript.yate
+++ b/yate/noscript.yate
@@ -15,7 +15,7 @@ external scalar ns-generate-url(/* layout */scalar, /* params */object)
  * data = model('name')
  */
 key model( /.models.*[ .status == 'ok' ], name() ) {
-    .data
+    .*[ name() != 'status' ]
 }
 
 /**
@@ -24,7 +24,7 @@ key model( /.models.*[ .status == 'ok' ], name() ) {
  * error = modelError('name')
  */
 key modelError( /.models.*[ .status == 'error' ], name() ) {
-    .data
+    .*[ name() != 'status' ]
 }
 
 // @private


### PR DESCRIPTION
Когда проектировали #273 , забыли об очень важном кейсе:

``` js
...
match model('someModelId') someMode
...

apply .someModelId someMode {
  ...
}

apply .someModelId[some condition] someMode {
  ...
}
```

Сейчас так не работает, т.к. функция model возвращает узел с именем `data`.

Суть изменения в том, что имя узла, содержащего данные модели, теперь совпадает с id модели. Минус этого подхода в том, что структура выглядит теперь масломаслянно:

```
{
  models: {
    messages: {
      messages: {...}
      status: 'ok'
    }
  }
}
```

Но т.к. мы настойчиво рекомендуем всегда использовать хелпер `model`, этот недостаток кажется незначительным.
