### PR TITLE
[ns.Model] Модель умеет наследоваться только через передачу класса

### DIFF
--- a/src/ns.model.js
+++ b/src/ns.model.js
@@ -536,7 +536,7 @@
      * @param {Function} [info.ctor] Конструтор.
      * @param {object} [info.methods] Методы прототипа.
      * @param {object} [info.params] Параметры модели, участвующие в формировании уникального ключа.
-     * @param {ns.Model} [base=ns.Model] Базовый класс для наследования
+     * @param {ns.Model|String} [base=ns.Model] Базовый класс для наследования или название ранее объявленной модели.
      * @examples
      * //  Простая модель, без параметров.
      * ns.Model.define('profile');
@@ -564,19 +564,26 @@
             info.isCollection = !!info.split;
         }
 
-        if (!base) {
+        var baseClass = base;
+        if (typeof base === 'string') {
+            // если указана строка, то берем декларацию ns.Model
+            baseClass = _ctors[base];
+            ns.assert(baseClass, 'ns.Model', "Can't find '%s' to extend '%s'", base, id);
+
+        } else if (!base) {
+            // если не указан, то определяем базовый класс из info
             if (info.uniq) {
-                base = ns.ModelUniq;
+                baseClass = ns.ModelUniq;
             } else if (info.isCollection) {
-                base = ns.ModelCollection;
+                baseClass = ns.ModelCollection;
             } else {
-                base = ns.Model;
+                baseClass = ns.Model;
             }
         }
 
         var ctor = info.ctor || function() {};
         // Нужно унаследоваться от base и добавить в прототип info.methods.
-        ctor = no.inherit(ctor, base, info.methods);
+        ctor = no.inherit(ctor, baseClass, info.methods);
 
         // часть дополнительной обработки производится в ns.Model.info
         // т.о. получаем lazy-определение

--- a/test/spec/ns.model.js
+++ b/test/spec/ns.model.js
@@ -100,44 +100,79 @@ describe('ns.Model', function() {
 
             beforeEach(function() {
 
-                var parent = ns.Model.define('parent', {
+                this.parent = ns.Model.define('parent', {
                     methods: {
                         superMethod: function() {}
                     }
                 });
 
-                ns.Model.define('child', {
-                    methods: {
-                        oneMore: function() {}
-                    }
-                }, parent);
-
-                this.model = ns.Model.get('child', {});
             });
 
             afterEach(function() {
-                delete this.model;
+                delete this.parent;
             });
 
-            it('наследуемая model должен быть ns.Model', function() {
-                expect(this.model instanceof ns.Model).to.be.equal(true);
+            describe('через конструктор родителя', function() {
+
+                beforeEach(function() {
+                    ns.Model.define('child', {
+                        methods: {
+                            oneMore: function() {}
+                        }
+                    }, this.parent);
+
+                    this.model = ns.Model.get('child', {});
+                });
+
+                afterEach(function() {
+                    delete this.model;
+                });
+
+                checkChildModel();
+
             });
 
-            it('методы наследуются от базовой модели', function() {
-                expect(this.model.superMethod).to.be.a('function');
+            describe('через название родителя', function() {
+
+                beforeEach(function() {
+
+                    ns.Model.define('child', {
+                        methods: {
+                            oneMore: function() {}
+                        }
+                    }, 'parent');
+
+                    this.model = ns.Model.get('child', {});
+                });
+
+                afterEach(function() {
+                    delete this.model;
+                });
+
+                checkChildModel();
             });
 
-            it('методы от базового model не ушли в ns.Model', function() {
-                expect(ns.Model.prototype.superMethod).to.be.an('undefined');
-            });
+            function checkChildModel() {
+                it('наследуемая model должен быть ns.Model', function() {
+                    expect(this.model instanceof ns.Model).to.be.equal(true);
+                });
 
-            it('методы ns.Model на месте', function() {
-                expect(this.model.isValid).to.be.a('function');
-            });
+                it('методы наследуются от базовой модели', function() {
+                    expect(this.model.superMethod).to.be.a('function');
+                });
 
-            it('методы из info.methods тоже не потерялись', function() {
-                expect(this.model.oneMore).to.be.a('function');
-            });
+                it('методы от базового model не ушли в ns.Model', function() {
+                    expect(ns.Model.prototype.superMethod).to.be.an('undefined');
+                });
+
+                it('методы ns.Model на месте', function() {
+                    expect(this.model.isValid).to.be.a('function');
+                });
+
+                it('методы из info.methods тоже не потерялись', function() {
+                    expect(this.model.oneMore).to.be.a('function');
+                });
+            }
         });
 
         describe('ns.Model.getValid():', function() {


### PR DESCRIPTION
Для вида можно родителя указать строкой

```
ns.View.define('childView', {}, 'parentView')
```

Для модели такая штука не прокатит, туда надо передавать сам класс.
Потому что https://github.com/yandex-ui/noscript/blob/master/src/ns.model.js#L579

Для view же делается все правильно https://github.com/yandex-ui/noscript/blob/master/src/ns.view.js#L1126
