### PR TITLE
 [ns.ModelCollection] #clear не кидает события. Fix #340

### DIFF
--- a/src/ns.modelCollection.js
+++ b/src/ns.modelCollection.js
@@ -262,22 +262,29 @@
     /**
      * Очищает коллекцию от моделей.
      * Не путать с remove.
+     * @fires ns.ModelCollection#ns-model-remove
      */
     ns.ModelCollection.prototype.clear = function() {
-        if (this.models) {
-            var that = this;
-            this.models.forEach(function(model) {
-                that._unsubscribeSplit(model);
-            });
-        }
+        var models = this.models;
 
         // Это нужно и для начальной инициализации моделей.
+        // Сначала удаляем все элементы, потом отписываем и бросаем событие
 
         /**
          * Массив с моделями - элементами коллекции.
          * @type {ns.Model[]}
          */
         this.models = [];
+
+        if (models && models.length) {
+            var that = this;
+            models.forEach(function(model) {
+                that._unsubscribeSplit(model);
+            });
+
+            // бросаем событие об удалении всех элементов
+            this.trigger('ns-model-remove', models);
+        }
     };
 
     /**

--- a/test/spec/ns.modelCollection.js
+++ b/test/spec/ns.modelCollection.js
@@ -26,15 +26,9 @@ describe('ns.ModelCollection', function() {
                 'event2': function() {
                     methodCallback();
                 },
-                'ns-model-changed': function() {
-                    changedCallback.apply(this, arguments);
-                },
-                'ns-model-insert': function() {
-                    insertCallback();
-                },
-                'ns-model-remove': function() {
-                    removeCallback();
-                }
+                'ns-model-changed': changedCallback,
+                'ns-model-insert': insertCallback,
+                'ns-model-remove': removeCallback
             },
 
             methods: {
@@ -519,7 +513,6 @@ describe('ns.ModelCollection', function() {
 
                 this.model = ns.Model.get('mc0', { id: Math.random() });
 
-                this.model.trigger = this.sinon.spy();
                 this.model.setData(this.data, { silent: true });
 
                 this.item1 = this.model.models[0];
@@ -546,6 +539,17 @@ describe('ns.ModelCollection', function() {
                 this.model.clear();
                 this.item1.trigger('event1');
                 expect(this.methodNameCallback.callCount).to.be.equal(0);
+            });
+
+            it('должен бросить собитие ns-model-removed', function() {
+                this.model.clear();
+                expect(this.removeCallback).to.have.callCount(1);
+            });
+
+            it('должен бросить собитие ns-model-removed cо всеми удаленными моделями', function() {
+                var MCItems = this.model.models;
+                this.model.clear();
+                expect(this.removeCallback).to.be.calledWith('ns-model-remove', MCItems);
             });
 
         });

--- a/test/spec/ns.viewCollection.events.models.js
+++ b/test/spec/ns.viewCollection.events.models.js
@@ -96,10 +96,10 @@ describe('ns.ViewCollection. Подписка на события моделей
                     view_id: 'line'
                 },
                 methods: {
-                    onInsert: this.onInsert = sinon.spy(),
-                    onRemove: this.onRemove = sinon.spy(),
-                    onChanged: this.onChanged = sinon.spy(),
-                    onDestroyed: this.onDestroyed = sinon.spy()
+                    onInsert: this.onInsert = this.sinon.spy(),
+                    onRemove: this.onRemove = this.sinon.spy(),
+                    onChanged: this.onChanged = this.sinon.spy(),
+                    onDestroyed: this.onDestroyed = this.sinon.spy()
                 }
             });
 
@@ -124,7 +124,10 @@ describe('ns.ViewCollection. Подписка на события моделей
             	ns.Model.destroy(this.collection);
 
                 expect(this.onInsert.callCount).to.equal(1);
-                expect(this.onRemove.callCount).to.equal(1);
+                // ns-model-remove кидается два раза
+                // один раз от this.collection.remove(itemOld);
+                // второй раз при destroy this.collection
+                expect(this.onRemove.callCount).to.equal(2);
                 expect(this.onChanged.callCount).to.equal(1);
                 expect(this.onDestroyed.callCount).to.equal(1);
             });


### PR DESCRIPTION
 Теперь #clear кидает событие ns-model-remove со всеми элементами.

Еще обратите внимание на изменение теста для `ViewCollection`. На `destroy` теперь кидается два события: `ns-model-remove` и `ns-model-destroy`
