### PR TITLE
Виды должны обновлять то, что отрендерили

### DIFF
--- a/src/ns.update.js
+++ b/src/ns.update.js
@@ -316,7 +316,7 @@
      * потому что у видов будет уже другое состояние, если что-то поменяется между generateHTML и insertNodes
      * @private
      */
-    ns.Update.prototype._updateViewTree = function() {
+    ns.Update.prototype._updateDOM = function() {
         if (this._expired()) {
             return this._rejectWithStatus(this.STATUS.EXPIRED);
         }
@@ -395,7 +395,7 @@
             .then(this._fulfill, this._reject)
          */
         this._requestAllModels().then(function(asyncResult) {
-            this._updateViewTree().then(function() {
+            this._updateDOM().then(function() {
                 this._fulfill(asyncResult);
             }, this._reject, this)
             // Если insertNodes кинет exception, то он ловится вот тут.

--- a/test/spec/ns.update.edge-cases.js
+++ b/test/spec/ns.update.edge-cases.js
@@ -7,8 +7,8 @@ describe('Виды должны обновлять то, что отрендер
         this.sinon.spy(ns.View.prototype, '_getUpdateTree');
         this.sinon.spy(ns.View.prototype, '_updateHTML');
 
-        var originalMethod = ns.Update.prototype._updateViewTree;
-        this.sinon.stub(ns.Update.prototype, '_updateViewTree', function() {
+        var originalMethod = ns.Update.prototype._updateDOM;
+        this.sinon.stub(ns.Update.prototype, '_updateDOM', function() {
             var result = originalMethod.call(this);
 
             // не придумал лучше способа как сделать такую проверку :(


### PR DESCRIPTION
Второй вариант для #370  - сделать рендеринг синхронным.

Под рендерингом тут понимается формирование дерева рендеринга, yate, вставка в DOM.

Кажется, что этот вариант намного проще и принесет меньше странных вещей
