### PR TITLE
[ns.ModelCollection] Убрал selfVersion

### DIFF
--- a/src/ns.modelCollection.js
+++ b/src/ns.modelCollection.js
@@ -203,9 +203,9 @@
      */
     ns.ModelCollection.prototype.onItemTouched = function(evt, model) {
         /* jshint unused: false */
-        // У коллекции есть собственная версия (this._versionSelf) и версия элементов коллекции (this._version).
-        // Когда меняется элемент коллекции - версия самой коллекции не меняется.
-        this._version++;
+
+        // Версия коллекции не должна зависить от версии элементов, поэтому
+        // когда меняется элемент коллекции - версия самой коллекции не меняется.
     };
 
     /**
@@ -215,29 +215,6 @@
      */
     ns.ModelCollection.prototype.onItemDestroyed = function(evt, model) {
         this.remove(model);
-    };
-
-    /**
-     * Returns data version (included items version).
-     * @returns {number}
-     */
-    ns.ModelCollection.prototype.getSelfVersion = function() {
-        return this._versionSelf;
-    };
-
-    /**
-     * Обновляет _version модели
-     */
-    ns.ModelCollection.prototype.touch = function() {
-        ns.Model.prototype.touch.apply(this, arguments);
-
-        /**
-         * _versionSelf показывает версию изменений внешней модели
-         * в то время, как _version - последнее время изменения внешней или внутренней модели
-         * @type {*}
-         * @private
-         */
-        this._versionSelf = this._version;
     };
 
     /**

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -117,36 +117,6 @@ ns.ViewCollection.prototype.isValidDesc = function() {
 };
 
 /**
- * Возвращает true, если все модели валидны.
- * @param {object} [modelsVersions] Также проверяем, что кеш модели не свежее переданной версии.
- * @returns {Boolean}
- */
-ns.ViewCollection.prototype.isModelsValid = function(modelsVersions) {
-    var models = this.models;
-    for (var id in models) {
-        /** @type ns.Model|ns.ModelCollection */
-        var model = models[id];
-        var modelVersion = model.getVersion();
-        // при сравнении с версией модели-коллекции используем versionSelf,
-        // не зависящий от внутренних моделей
-        if (ns.Model.isCollection(model)) {
-            modelVersion = model.getSelfVersion();
-        }
-
-        if (
-            // модель не валидна
-            !model.isValid() ||
-            // или ее кеш более свежий
-            (modelsVersions && modelVersion > modelsVersions[id])
-        ) {
-            return false;
-        }
-    }
-
-    return true;
-};
-
-/**
  *
  * @param {string} id
  * @param {object} params

--- a/test/spec/ns.modelCollection.js
+++ b/test/spec/ns.modelCollection.js
@@ -742,6 +742,15 @@ describe('ns.ModelCollection', function() {
 
         });
 
+        it('изменение версии элемента не изменяет версию коллекции', function() {
+            var oldVersion = this.mc.getVersion();
+            this.models[0].touch();
+
+            expect(this.mc.getVersion())
+                .to.be.equal(oldVersion)
+                .and.to.be.a('number');
+        });
+
     });
 
     describe('Разнородная коллекция', function() {


### PR DESCRIPTION
Она вроде как не нужна и нигде не использовалась

Нашел это из-за такой баги.
ViewCollection проверяет валидность по собственной версии коллекции https://github.com/yandex-ui/noscript/blob/master/src/ns.viewCollection.js#L133, а сохраняет другую https://github.com/yandex-ui/noscript/blob/master/src/ns.view.js#L1110
