### PR TITLE
ns.Model#touch() должен попадать под подписку видов на модель

### DIFF
--- a/test/spec/ns.viewCollection.js
+++ b/test/spec/ns.viewCollection.js
@@ -604,7 +604,7 @@ describe('ns.ViewCollection', function() {
                 // touching model after a small timeout to guarantee, that
                 // model and view will have different timeout attribute
                 window.setTimeout(function() {
-                    ns.Model.get('m-collection').touch();
+                    ns.Model.get('m-collection').touch({silent: true});
 
                     // start update to redraw a core view
                     var layout = ns.layout.page('app', {});


### PR DESCRIPTION
Сделал, что changed генерится в touch.
Т.о. сохранил старое поведение и сделал, что .touch() попадает под подписки видов на модель.
Без этого сейчас получается странная ситуация, что модель прописана на keepValid, но если ей сделать touch(), то она будет все равно перерисована, потому что при следующем update у нее не совпадут версии.

В разговоре с @esdoroshenko выяснил, что подписка вида на `ns-model-touched` модели была исключена умышленно. Потому что `ns-model-touched` и `ns-model-touched` генерятся парами, а значит, что и обработку этих событий надо описывать парами, иначе в `changed` можно оставить вид валидным, а `touched` его все равно инвалидирует.

Также мы с ним решили, что само событие `ns-model-touched` избыточно, опять же из-за парности и `ns-model-changed`
