### PR TITLE
[ns.ViewCollection] #invalidate должен инвалидировать только себя

### DIFF
--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -147,6 +147,20 @@ ns.ViewCollection.prototype.isModelsValid = function(modelsVersions) {
 };
 
 /**
+ * Делает вид невалидным.
+ * @description Cтатус валидности самой коллекции и ее элементов рассчитыается независимо.
+ * Поэтому этот метод инвалидирует только себя и оставляет элементы коллекции без изменений.
+ */
+ns.ViewCollection.prototype.invalidate = function() {
+    this.status = this.STATUS.INVALID;
+};
+
+/**
+ * @borrows ns.View.prototype.invalidate as ns.ViewCollection.prototype.invalidateAll
+ */
+ns.ViewCollection.prototype.invalidateAll = ns.View.prototype.invalidate;
+
+/**
  *
  * @param {string} id
  * @param {object} params

--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -675,6 +675,41 @@ describe('ns.View', function() {
 
     });
 
+    describe('#invalidate.', function() {
+
+        beforeEach(function() {
+            this.sinon.spy(ns.View.prototype, 'invalidate');
+            ns.layout.define('app', {
+                'view1': {
+                    'view2': {}
+                }
+            });
+
+            ns.View.define('view1');
+            ns.View.define('view2');
+            ns.View.define('view3');
+
+            this.view = ns.View.create('view1');
+
+            return new ns.Update(
+                this.view,
+                ns.layout.page('app'),
+                {}
+            ).render();
+        });
+
+        it('должен инвалидировать вид', function() {
+            this.view.invalidate();
+            expect(this.view.isValid()).to.be.equal(false);
+        });
+
+        it('должен инвалидировать дочерние виды', function() {
+            this.view.invalidate();
+            expect(this.view.views['view2'].isValid()).to.be.equal(false);
+        });
+
+    });
+
     describe('#patchTree()', function() {
 
         beforeEach(function(done) {


### PR DESCRIPTION
Сейчас коллекция устроена так, что статусы валидности для коллекции и ее элементов независимы.
В то же время .set() или .touch() для зависимой модели-коллекции приведут к полной перерисовки коллекции, что неверно, потому что должен перерисоваться только контейнер коллекции, но не ее элементы, которые остались валидными.

Проблема заключается в методе invalidate у ViewCollection, который не должен обрабатывать детей.

Заодно убрал забытый мною хак https://github.com/yandex-ui/noscript/blob/master/test/spec/ns.viewCollection.js#L607. Он появился, когда touch() тоже попал под подписку на модели.
