### PR TITLE
Исправление перерисовки вложенных коллекций видов для случая VC > VC > V

### DIFF
--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -285,12 +285,10 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
             if (this.isValidSelf()) {
                 // Если корневая нода не меняется, то перерендериваем
                 // только невалидные элементы коллекции
-                if (!view.isValid()) {
-                    if (view.info.isCollection && view.isValidSelf()) {
-                        decl = view._getPlaceholderTree(layout, params);
-                    } else {
-                        decl = view._getViewTree(layout, params);
-                    }
+                if (view.info.isCollection && view.isValidSelf()) {
+                    decl = view._getPlaceholderTree(layout, params);
+                } else if (!view.isValid()) {
+                    decl = view._getViewTree(layout, params);
                 }
             } else {
                 // Если же мы решили перерендеривать корневую ноду, то придётся рендерить все


### PR DESCRIPTION
Примерная ситуация:
- Есть коллекция `albums`, внутри нее лежит коллекция `album`.
- Внутри `album` лежат виды `photo`.
- Сейчас при добавлении нового `album` (например, `albums.insert(newAlbum, 5)`) все другие коллекции `album`, стоящие до нее, пустеют (имеют пустой `<div class="ns-view-container-desc" />`).

Я вроде постарался поправить, но вполне возможно, что есть более точный фикс.
