### PR TITLE
[ns.router] Прозрачная поддержка хешей как урлов

### DIFF
--- a/src/ns.router.js
+++ b/src/ns.router.js
@@ -321,7 +321,7 @@ ns.router.compile = function(route) {
     // смысл это махинации - поставить правильный символ в начале урла
     // все секции генерятся с / в начале
     // поэтому заменяем первый символ на константу
-    if (sregexps[0] === ns.router.URL_FIRST_SYMBOL) {
+    if (sregexps[0] === '/') {
         sregexps[0] = ns.router.URL_FIRST_SYMBOL + sregexps[0].substr(1);
     }
     var regexp = sregexps.join('');


### PR DESCRIPTION
Сейчас ns заточен на современный History API и это хорошо. И чтобы переделать все на хеши приходится переопределять `ns.router`.

Я добавил понятие "первый символ урла", чтобы его можно было переопределить как #

Сама поддержка хешей теперь может быть реализована в плагине без каких-либо хаков. Там надо будет переопределить "перый символ" и в `ns.history` подписаться на `hashchange`, а не `popstate`
