### PR TITLE
[ns.page] Вызов ns.page.go порождает дублирование истории

### DIFF
--- a/src/ns.page.js
+++ b/src/ns.page.js
@@ -19,19 +19,28 @@
     ns.page.currentUrl = null;
 
     /**
+     * Действие с историей по умолчанию.
+     * @constant
+     * @type {string}
+     */
+    ns.page.DEFAULT_HISTORY_ACTION = 'push';
+
+    /**
      * Осуществляем переход по ссылке.
      * @param {string} [url=ns.page.getCurrentUrl()]
-     * @param {string|boolean} [action='push'] Добавить, заменить ('replace') запись, не модифицировать ('preserve') историю браузера.
+     * @param {string} [historyAction='push'] Действие с историей браузера: добавить ('push'), заменить ('replace'), ничего не делать ('preserve').
      * @returns {Vow.Promise}
      * @fires ns.page#ns-page-after-load
      * @fires ns.page#ns-page-before-load
      * @fires ns.page#ns-page-error-load
      */
-    ns.page.go = function(url, action) {
-        if (!action) {
-            action = 'push';
-        } else if (action === true) {
-            action = 'replace';
+    ns.page.go = function(url, historyAction) {
+        if (!historyAction) {
+            historyAction = ns.page.DEFAULT_HISTORY_ACTION;
+
+        } else if (historyAction === true) {
+            // этот вариант оставлен для совместимости
+            historyAction = 'replace';
         }
 
         url = url || ns.page.getCurrentUrl();
@@ -54,7 +63,7 @@
         }
 
         if (route.page === ns.R.NOT_APP_URL) {
-            if (action === 'replace') {
+            if (historyAction === 'replace') {
                 window.location.replace(route.redirect);
             } else {
                 window.location = route.redirect;
@@ -74,15 +83,15 @@
 
         // не надо пушить в историю тот же самый URL
         // это очень легко сделать, если просто обновлять страницу через ns.page.go()
-        if (action === 'push' && url === ns.page.currentUrl) {
-            action = 'replace';
+        if (historyAction === 'push' && url === ns.page.currentUrl) {
+            historyAction = 'preserve';
         }
 
         return ns.page.followRoute(route)
             .then(function() {
 
                 ns.page._setCurrent(route, url);
-                ns.page._fillHistory(url, action);
+                ns.page._fillHistory(url, historyAction);
                 ns.page.title();
 
                 return ns.page.startUpdate(route);
@@ -124,8 +133,8 @@
      * @private
      */
     ns.page._fillHistory = function(url, action) {
+        // action еще может быть "preserve", т.е. ничего не делаем
         if (action === 'push') {
-            // записываем в историю все переходы
             ns.history.pushState(url);
 
         } else if (action === 'replace') {
@@ -159,6 +168,7 @@
      */
     ns.page._reset = function() {
         this.current = {};
+        this.currentUrl = '';
     };
 
     /**

--- a/test/spec/ns.page.js
+++ b/test/spec/ns.page.js
@@ -203,7 +203,7 @@ describe('ns.page', function() {
                             ns.page._fillHistory.reset();
 
                             return ns.page.go('/inbox').then(function() {
-                                expect(ns.page._fillHistory).to.be.calledWith('/inbox', 'replace');
+                                expect(ns.page._fillHistory).to.be.calledWith('/inbox', 'preserve');
                             });
                         });
                 });


### PR DESCRIPTION
Каждый вызов ns.page.go() без параметров добавляет в историю браузера точно такой же URL и кнопка "Назад" работает неправильно
