### PR TITLE
[ns.View] Правильное построение ключа, если model.params - функция

### DIFF
--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -1560,10 +1560,31 @@
      * @private
      */
     ns.View._getKeyParams = function(id, params, info) {
+        var extendedModels = {};
+        var paramsExtendedByModels = false;
+        // расширяем params параметрами из моделей, у которых info.params - функция
+        for (var model in info.models) {
+            var modelInfo = ns.Model.info(model);
+            if (typeof modelInfo.params === 'function') {
+                paramsExtendedByModels = true;
+                no.extend(extendedModels, modelInfo.params(params));
+            }
+        }
+
+        if (paramsExtendedByModels) {
+            // расширяем оригинальными params, чтобы они все перетерли
+            no.extend(extendedModels, params);
+            params = extendedModels;
+        }
+
         var pGroups = info.pGroups || [];
 
         // Группы параметров могут быть не заданы (это ок).
         if (!pGroups.length) {
+            // если нет собственных групп, но есть параметры модели, то надо брать их
+            if (paramsExtendedByModels) {
+                return params;
+            }
             return {};
         }
 

--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -714,6 +714,30 @@ describe('ns.View', function() {
                 expect(ns.View.getKeyAndParams('view', {}).key).to.eql('view=view');
             });
 
+            it('должен построить ключ по параметрам модели', function() {
+
+                ns.Model.define('model1', {
+                    params: function() {
+                        return {
+                            'p1': 'v1'
+                        }
+                    }
+                });
+                ns.Model.define('model2', {
+                    params: function() {
+                        return {
+                            'p2': 'v2'
+                        }
+                    }
+                });
+
+                ns.View.define('view', {
+                    models: ['model1', 'model2']
+                });
+
+                expect(ns.View.getKeyAndParams('view', {}).key).to.eql('view=view&p1=v1&p2=v2');
+            });
+
         });
 
     });


### PR DESCRIPTION
Если model.params - функция, то параметры оттуда не попали в ключ, и такие виды нельзя было положить в бокс.

Еще исправил #335 
