### PR TITLE
New async collection

### DIFF
--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -1178,6 +1178,14 @@
     };
 
     /**
+     * Сообщает виду промис, который его обновляет
+     * @param {Vow.Promise} promise
+     */
+    ns.View.prototype.canUpdateAfter = function(promise) {
+        /* jshint unused: false */
+    };
+
+    /**
      * Запускает на себе ns.Update
      * @param {object} [params] Дополнительные параметры. Могут использоваться при ручном запуске.
      * @param {ns.Update~options} [options] Опции исполнения. Если указан execFlag, то запускается ASYNC-обновление.

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -281,6 +281,12 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
                 view = this._addView(viewItem.id, viewItem.params);
             }
 
+            // проставляем для элемента коллекции правильный state
+            view._tryPushToRequest({
+                sync: [],
+                async: []
+            });
+
             decl = null;
             if (this.isValidSelf()) {
                 // Если корневая нода не меняется, то перерендериваем

--- a/test/spec/ns.ViewCollection.async.js
+++ b/test/spec/ns.ViewCollection.async.js
@@ -1,0 +1,95 @@
+xdescribe('ns.ViewCollection с async-видами', function() {
+
+    beforeEach(function(done) {
+
+        this.asyncSpy = this.sinon.spy();
+        this.htmlinitSpy = this.sinon.spy();
+        this.showSpy = this.sinon.spy();
+
+        this.sinon.spy(ns, 'Update');
+
+        ns.Model.define('mc', {
+            split: {
+                items: '/',
+                model_id: 'mc-item',
+                params: {
+                    id: '.id'
+                }
+            }
+        });
+
+        ns.Model.define('mc-item', {
+            params: {id: null}
+        });
+
+        ns.Model.define('other-model');
+
+        ns.Model.get('mc').setData([
+            {item: 1, id: 1},
+            {item: 2, id: 2}
+        ]);
+
+        ns.ViewCollection.define('vc', {
+            models: ['mc'],
+            split: {
+                byModel: 'mc',
+                intoViews: 'vc-item'
+            }
+        });
+
+        ns.View.define('vc-item', {
+            events: {
+                'ns-view-init': function() {
+                    //FIXME: хак. Делаем вид async
+                    this.async = true;
+                },
+                'ns-view-async': this.asyncSpy,
+                'ns-view-htmlinit': this.htmlinitSpy,
+                'ns-view-show': this.showSpy
+            },
+            models: ['mc-item', 'other-model']
+        });
+
+        ns.View.define('app', {});
+
+        ns.layout.define('test', {
+            'app': {
+                'vc': {}
+            }
+        });
+
+        var view = ns.View.create('app');
+
+        new ns.Update(
+            view,
+            ns.layout.page('test'),
+            {}
+        ).render().then(function(value) {
+                //FIXME: элементы коллекции не добавляются как async-промисы :(
+                window.setTimeout(function() {
+                    done();
+                }, 100);
+            }, function(err) {
+                done(err);
+            });
+
+    });
+
+    it('должен два раза вызвать ns-view-async', function() {
+        expect(this.asyncSpy).to.have.callCount(2);
+    });
+
+    it('не должен вызвать ns-view-htmlinit для async', function() {
+        expect(this.htmlinitSpy).to.have.callCount(0);
+    });
+
+    it('не должен вызвать ns-view-show для async', function() {
+        expect(this.showSpy).to.have.callCount(0);
+    });
+
+    it('должен запустить два async update', function() {
+        expect(ns.Update.getCall(1).args[0].key).to.be.equal("view=vc-item&id=2");
+        expect(ns.Update.getCall(2).args[0].key).to.be.equal("view=vc-item&id=1");
+    });
+
+});

--- a/test/spec/ns.ViewCollection.async.js
+++ b/test/spec/ns.ViewCollection.async.js
@@ -1,4 +1,4 @@
-xdescribe('ns.ViewCollection с async-видами', function() {
+describe('ns.ViewCollection с async-видами', function() {
 
     beforeEach(function(done) {
 


### PR DESCRIPTION
Возвращаемся к нашим баранам из #393 :) Этот таск про "поговорить", а не про "мержить"

Проблема все та же: есть элемент ViewCollection является асинхронным, то его никто не будет отрисовывать. 
С другой стороны, для меня задача звучит "научить виды понимать, когда завершился update, который их рисует". Это позволит неасинхронным элементам коллекции дозапрашивать свои данные и перерисовываться. Ведь просто запустить this.update на `ns-view-show` не получится, т.к. в это время работает глобальный апдейте и async он не пустит.

Итак, благодаря разлиным доработкам ns, первая проблема решилась вот так: https://github.com/yandex-ui/noscript/pull/429/files#diff-99260eb984accfc9a5081d90c62bba1eR323
Вторую (более общую задачу) задачу я решил вот так: https://github.com/yandex-ui/noscript/pull/429/files#diff-99260eb984accfc9a5081d90c62bba1eR308

Все это - реализация идеи, озвученной вот тут https://github.com/yandex-ui/noscript/issues/393#issuecomment-51774454