### PR TITLE
Fix model hasdatachanged

### DIFF
--- a/src/ns.model.js
+++ b/src/ns.model.js
@@ -272,7 +272,7 @@
         // переинициализация после #destroy()
         this._reinit();
 
-        if (data && this.hasDataChanged(data)) {
+        if (data && (!this.isValid() || this.hasDataChanged(data))) {
 
             /**
              * Данные модели.


### PR DESCRIPTION
Обнаружилась проблема у метода `hasDataChanged`:
после инвалидации модели не выполнялся метод `setData` со старыми данными, хотя модель была невалидна

``` js
var m = ns.Model.get('m11');
m.setData({ version: 1 });
m.invalidate();
m.setData({ version: 1 }); // Вот этот метод не выполнялся, хотя, кажется, должен
```
