### PR TITLE
Обновить nommon до чего-то более менее последнего

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nommon": "0.0.23",
+        "nommon": "0.0.32",
         "vow": "0.3.13"
     },
     "main": "./dist/noscript.module.js",


### PR DESCRIPTION
У нас сейчас версия `0.0.23` - ей уже больше года.

Там есть такой баг в jpath:

``` js
// 0.0.23
no.jpath('.a || .b', { a: 'a', b: 'b'}) // => true

// 0.0.32
no.jpath('.a || .b', { a: 'a', b: 'b'}) // => 'a'
```

Все за?
