### PR TITLE
[ns.Events] Надо бросить исключение, если не передали обработчик в #on

### DIFF
--- a/src/ns.events.js
+++ b/src/ns.events.js
@@ -20,6 +20,8 @@ ns.Events = {};
 ns.Events.on = function(name, handler) {
     var handlers = this._nsevents_handlers || (( this._nsevents_handlers = {} ));
 
+    ns.assert(typeof handler === 'function', 'ns.Events', 'Handler for event "%s" in not a function.', name);
+
     ( handlers[name] || (( handlers[name] = [] )) ).push(handler);
 
     return this;

--- a/test/spec/ns.events.js
+++ b/test/spec/ns.events.js
@@ -87,6 +87,32 @@ describe('ns.Events', function() {
 
     });
 
+    describe('#on', function() {
+
+        it('должен бросить исключение, если не передан обработчик', function() {
+            this.foo = {};
+            no.extend(this.foo, ns.Events);
+
+            var fn = function() {
+                ns.Events.on('event');
+            };
+
+            expect(fn).to.throw();
+        });
+
+        it('должен бросить исключение, если передана не функция', function() {
+            this.foo = {};
+            no.extend(this.foo, ns.Events);
+
+            var fn = function() {
+                ns.Events.on('event', {});
+            };
+
+            expect(fn).to.throw();
+        });
+
+    });
+
     describe('#once', function() {
 
         beforeEach(function() {


### PR DESCRIPTION
Это явная ошибка разработчика, удобно сразу по нее говорить.
