### PR TITLE
Не нужно вызывать `require('request')` если мы переопределили ns.http

### DIFF
--- a/src/ns.http.server.js
+++ b/src/ns.http.server.js
@@ -1,5 +1,3 @@
-var request = require('request');
-
 /**
  * Creates and executes http request (a POST request with json return data type by default).
  * @param {string} uri
@@ -8,6 +6,7 @@ var request = require('request');
  * @returns {Vow.Promise}
  */
 ns.http = function(uri, params, options) {
+    var request = require('request');
 
     options = no.extend(ns.H.DEFAULTS, options || {});
 


### PR DESCRIPTION
Мы переопределяем метод `ns.http`, но строчка

```
var request = require('request')
```

всё равно выполняется и всё падает из-за отсутствия этого модуля, хотя на самом деле он нам не нужен.
