### PR TITLE
[ns.Update] Оптимизировал цепочку промисов

### DIFF
--- a/src/ns.update.js
+++ b/src/ns.update.js
@@ -280,7 +280,6 @@
      * @private
      * @param {HTMLElement} node
      * @param {boolean} async
-     * @returns {Vow.Promise}
      */
     ns.Update.prototype._insertNodes = function(node, async) {
         if (this._expired()) {
@@ -347,7 +346,7 @@
 
         var html = this._renderUpdateTree();
         var node = ns.html2node(html || '');
-        return this._insertNodes(node);
+        this._insertNodes(node);
     };
 
     /**
@@ -409,20 +408,14 @@
 
         this.log('started `render` scenario');
 
-        var asyncViewPromises;
-        var saveAsyncPromises = function(result) {
-            // сохраняем результат
-            asyncViewPromises = result;
-        };
-        var fulfillWithAsyncPromises = function() {
-            this._fulfill(asyncViewPromises);
-        };
-
         // начинаем цепочку с промиса, чтобы ловить ошибки в том числе и из _requestAllModels
         Vow.invoke(this._requestAllModels.bind(this))
-            .then(saveAsyncPromises, null, this)
-            .then(this._updateDOM, null, this)
-            .then(fulfillWithAsyncPromises, this._reject, this);
+            .then(function(result) {
+                this._updateDOM();
+                this._fulfill(result);
+            }, this._reject, this)
+            // еще один reject, чтобы ловить ошибки из #_updateDOM
+            .then(null, this._reject, this);
 
         return this.promise;
     };

--- a/test/spec/ns.update.stage-errors.js
+++ b/test/spec/ns.update.stage-errors.js
@@ -47,17 +47,6 @@ describe('ns.Update: ловля ошибок на разных стадиях.',
                     })
             });
 
-            it('должен поймать ошибку и отреджектить промис, если #' + method + '() реджектит свой промис.', function() {
-                this.sinon.stub(ns.Update.prototype, method).returns(Vow.reject('oops'));
-
-                return this.update[updateMethodToCall]()
-                    .then(function() {
-                        return Vow.reject('fulfilled');
-                    }, function() {
-                        return Vow.fulfill();
-                    })
-            });
-
         });
 
     }


### PR DESCRIPTION
Станет немного быстрее.
Убрал возврат промисов из #_insertNodes и #_updateDOM, он все равно статичный
Из #_render убрал цепочки для запоминания async-промисов, сделав их синхронными.