### PR TITLE
[ns.View] Разделил методы подписки на модели и модель

### DIFF
--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -167,7 +167,7 @@ describe('ns.View', function() {
             );
 
             var view = ns.View.create('test-view', {});
-            view._bindModels();
+            view.__bindModelsEvents();
             model.setData({a : 2});
         });
 
@@ -193,7 +193,7 @@ describe('ns.View', function() {
             );
 
             var view = ns.View.create('test-view', {});
-            view._bindModels();
+            view.__bindModelsEvents();
             model.setData({a : 2});
         });
     });


### PR DESCRIPTION
Мне для некоторых экспериментальных плагинов нужен отдельный метод для снятия и навешивания обработчиков событий **одной** модели. Собсно выделил это метод из `_bindModels` и `_unbindModels`

Также сделал имена методов чуть лучше (на мой вкус)
`bindModelsEvents` (все модели) -> `__bindModelEvents` (одна модель) -> `__bindModelEvent` (одна модель + обработчик)
