### PR TITLE
[ns.View] Убрал прокидывание layout в #getUpdateTree

### DIFF
--- a/src/ns.box.js
+++ b/src/ns.box.js
@@ -160,35 +160,31 @@ ns.Box.prototype._getViewTree = function(params) {
     return tree;
 };
 
-ns.Box.prototype.beforeUpdateHTML = function(layout, params, events) {
-    var newLayout = {};
-    for (var id in layout) {
-        var selfLayout = layout[id];
-        var key = this._getViewKey(id, params, selfLayout.type);
-        newLayout[id] = key;
-
+ns.Box.prototype.beforeUpdateHTML = function(params, events) {
+    var activeLayout = this.active;
+    for (var viewId in activeLayout) {
+        var viewKey = activeLayout[viewId];
         //  Достаем ранее созданный блок (в _getRequestViews).
         /** @type {ns.View} */
-        var view = this.views[key];
-        view.beforeUpdateHTML(layout[view.id].views, params, events);
+        var view = this.views[viewKey];
+        view.beforeUpdateHTML(params, events);
     }
 
-    this._hideInactiveViews(newLayout, events);
+    this._hideInactiveViews(events);
 };
 
 /**
  * Скрываем все неактивные виды в боксе
- * @param {object} newLayout
  * @param {object} events
  * @private
  */
-ns.Box.prototype._hideInactiveViews = function(newLayout, events) {
+ns.Box.prototype._hideInactiveViews = function(events) {
     var hideEvents = events['ns-view-hide'];
     // Пройдёмся по всем вложенным видам, чтобы кинуть hide, которым не попали в newLayout
     for (var key in this.views) {
         var view = this.views[key];
         // Если вид не входит в новый active
-        if (newLayout[view.id] !== view.key) {
+        if (this.active[view.id] !== view.key) {
 
             // Скроем виды, не попавшие в layout
             var descs = view._getDescendantsAndSelf( [] );

--- a/src/ns.update.js
+++ b/src/ns.update.js
@@ -292,7 +292,7 @@
             'ns-view-hide': [],
             'ns-view-htmldestroy': []
         };
-        this.view.beforeUpdateHTML(this.layout.views, this.params, hideViewEvents);
+        this.view.beforeUpdateHTML(this.params, hideViewEvents);
         this._triggerViewEvents(hideViewEvents);
 
         var viewEvents = {

--- a/src/ns.update.js
+++ b/src/ns.update.js
@@ -260,7 +260,7 @@
         var tree = {
             'views': {}
         };
-        this.view._getUpdateTree(tree, this.layout.views, this.params);
+        this.view._getUpdateTree(tree, this.params);
         this.log('created render tree', tree);
         this.stopTimer('collectViews');
 

--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -746,12 +746,12 @@
      *  В tree.models будут все модели, требуемые для этих блоков.
      *  @private
      */
-    ns.View.prototype._getUpdateTree = function(tree, layout, params) {
+    ns.View.prototype._getUpdateTree = function(tree, params) {
         if ( !this.isValid() ) {
-            tree.views[this.id] = this._getViewTree(layout, params);
+            tree.views[this.id] = this._getViewTree(params);
         } else {
-            this._apply(function(view, id) {
-                view._getUpdateTree(tree, layout[id].views, params);
+            this._apply(function(view) {
+                view._getUpdateTree(tree, params);
             });
         }
 
@@ -812,12 +812,11 @@
 
     /**
      * Строим дерево блоков.
-     * @param {object} layout Currently processing layout.
      * @param {object} params Params.
      * @returns {ns.View~UpdateTree}
      * @private
      */
-    ns.View.prototype._getViewTree = function(layout, params) {
+    ns.View.prototype._getViewTree = function(params) {
         var tree = this._getTree();
 
         // всегда собираем данные, в том числе закешированные модели для async-view
@@ -835,12 +834,7 @@
 
         //  Сюда попадают только синхронные блоки.
 
-        //  Это блок без подблоков.
-        if (typeof layout !== 'object') {
-            return true;
-        }
-
-        tree.views = this._getDescViewTree(layout, params);
+        tree.views = this._getDescViewTree(params);
 
         return tree;
     };
@@ -871,16 +865,15 @@
 
     /**
      * Возвращает деревья для дочерних видов
-     * @param {object} layout
      * @param {object} params
      * @returns {object.<string, ns.View~UpdateTree>}
      * @private
      */
-    ns.View.prototype._getDescViewTree = function(layout, params) {
+    ns.View.prototype._getDescViewTree = function(params) {
         var views = {};
         //  Собираем дерево рекурсивно из подблоков.
         this._apply(function(view, id) {
-            views[id] = view._getViewTree(layout[id].views, params);
+            views[id] = view._getViewTree(params);
         });
 
         return views;
@@ -888,16 +881,15 @@
 
     /**
      * Возвращает декларацию вида для вставки плейсхолдера
-     * @param {object} layout Currently processing layout.
      * @param {object} params Params.
      * @returns {ns.View~UpdateTree}
      * @private
      */
-    ns.View.prototype._getPlaceholderTree = function(layout, params) {
+    ns.View.prototype._getPlaceholderTree = function(params) {
         var tree = this._getTree();
         tree.collection = true;
         tree.state = 'placeholder';
-        tree.views = this._getDescViewTree(layout, params);
+        tree.views = this._getDescViewTree(params);
 
         return tree;
     };

--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -1014,13 +1014,13 @@
         }
     };
 
-    ns.View.prototype.beforeUpdateHTML = function(layout, params, events) {
+    ns.View.prototype.beforeUpdateHTML = function(params, events) {
         this._selfBeforeUpdateHTML(events);
 
         //  Рекурсивно идем вниз по дереву, если не находимся в async-режиме
         if (!this.asyncState) {
-            this._apply(function(view, id) {
-                view.beforeUpdateHTML(layout[id].views, params, events);
+            this._apply(function(view) {
+                view.beforeUpdateHTML(params, events);
             });
         }
     };

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -361,13 +361,13 @@ ns.ViewCollection.prototype._getViewTree = function(params) {
     return tree;
 };
 
-ns.ViewCollection.prototype.beforeUpdateHTML = function(layout, params, events) {
+ns.ViewCollection.prototype.beforeUpdateHTML = function(params, events) {
     this._selfBeforeUpdateHTML(events);
 
     // проходимся по элементам коллекции
     if (!this.isLoading()) {
         this._forEachCollectionItem(function(view) {
-            view.beforeUpdateHTML(null, params, events);
+            view.beforeUpdateHTML(params, events);
         }, params);
     }
 };

--- a/src/ns.viewCollection.js
+++ b/src/ns.viewCollection.js
@@ -234,17 +234,16 @@ ns.ViewCollection.prototype._getRequestViews = function(updated, pageLayout) {
 /**
  *
  * @param {object} tree
- * @param {object} layout
  * @param {object} params
  * @returns {ns.View~UpdateTree}
  * @private
  */
-ns.ViewCollection.prototype._getUpdateTree = function(tree, layout, params) {
+ns.ViewCollection.prototype._getUpdateTree = function(tree, params) {
     var decl;
     if (this.isValidSelf()) {
-        decl = this._getPlaceholderTree(layout, params);
+        decl = this._getPlaceholderTree(params);
     } else {
-        decl = this._getViewTree(layout, params);
+        decl = this._getViewTree(params);
     }
 
     // Добавим декларацию этого ViewCollection в общее дерево
@@ -279,12 +278,11 @@ ns.ViewCollection.prototype._forEachCollectionItem = function(cb, params) {
 
 /**
  *
- * @param {object} layout
  * @param {object} params
  * @returns {object.<string, ns.View~UpdateTree>}
  * @private
  */
-ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
+ns.ViewCollection.prototype._getDescViewTree = function(params) {
     var that = this;
     var result = {};
     result['ns-view-collection-container'] = [];
@@ -295,9 +293,9 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
             // Если корневая нода не меняется, то перерендериваем
             // только невалидные элементы коллекции
             if (view.info.isCollection && view.isValidSelf()) {
-                decl = view._getPlaceholderTree(layout, params);
+                decl = view._getPlaceholderTree(params);
             } else if (!view.isValid()) {
-                decl = view._getViewTree(layout, params);
+                decl = view._getViewTree(params);
             }
         } else {
             // Если же мы решили перерендеривать корневую ноду, то придётся рендерить все
@@ -305,10 +303,10 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
             if (view.isValidSelf()) {
                 // если view - обычный вид, то isValidSelf === isValid
                 // если view - коллекция, то она проверит себя (isValidSelf) и сделаем дерево для детей
-                decl = view._getPlaceholderTree(layout, params);
+                decl = view._getPlaceholderTree(params);
 
             } else {
-                decl = view._getViewTree(layout, params);
+                decl = view._getViewTree(params);
             }
         }
 
@@ -348,18 +346,17 @@ ns.ViewCollection.prototype._getDescViewTree = function(layout, params) {
 
 /**
  *
- * @param {object} layout
  * @param {object} params
  * @returns {ns.View~UpdateTree}
  * @private
  */
-ns.ViewCollection.prototype._getViewTree = function(layout, params) {
+ns.ViewCollection.prototype._getViewTree = function(params) {
     var tree = this._getTree();
     tree.collection = true;
     // всегда собираем данные, в том числе закешированные модели для async-view
     tree.models = this._getModelsForTree();
 
-    tree.views = this._getDescViewTree(layout, params);
+    tree.views = this._getDescViewTree(params);
 
     return tree;
 };


### PR DESCRIPTION
У него нет применения и мы зря тратим память и CPU
А еще мы начнем в 3 раза меньше считать ключи для видов в боксе!