### PR TITLE
[ns.ModelCollection] Передавать в событие 'ns-model-remove' модель элемента коллекции с данными при её уничтожении

### DIFF
--- a/src/ns.modelCollection.js
+++ b/src/ns.modelCollection.js
@@ -183,7 +183,7 @@
             that.onItemTouched(evt, model);
         });
 
-        this.bindModel(model, 'ns-model-destroyed', function(evt) {
+        this.bindModel(model, 'ns-model-before-destroyed', function(evt) {
             that.onItemDestroyed(evt, model);
         });
     };
@@ -287,8 +287,8 @@
 
     /**
      * Метод вызывается, когда уничтожается элемент коллекции.
-     * @param {string} evt Событие 'ns-model-destroyed' от элемента коллекции.
-     * @param {ns.Model} model Уничтоженный элемент коллекции.
+     * @param {string} evt Событие 'ns-model-before-destroyed' от элемента коллекции.
+     * @param {ns.Model} model Уничтожаемый элемент коллекции.
      */
     ns.ModelCollection.prototype.onItemDestroyed = function(evt, model) {
         this.remove(model);

--- a/test/spec/ns.modelCollection.js
+++ b/test/spec/ns.modelCollection.js
@@ -720,13 +720,13 @@ describe('ns.ModelCollection', function() {
                 expect(this.onItemTouchedSpy.calledWithExactly('ns-model-touched', touchedModel)).to.be.equal(true);
             });
 
-            it('ns-model-destroyed', function() {
+            it('ns-model-before-destroyed', function() {
                 var destroyedModel = this.models[1];
                 var countElementsBefore = this.mc.models.length;
 
                 destroyedModel.destroy();
                 expect(this.onItemDestroyedSpy.callCount).to.be.equal(1);
-                expect(this.onItemDestroyedSpy.calledWithExactly('ns-model-destroyed', destroyedModel)).to.be.equal(true);
+                expect(this.onItemDestroyedSpy.calledWithExactly('ns-model-before-destroyed', destroyedModel)).to.be.equal(true);
                 expect(this.mc.models.length).to.be.equal(countElementsBefore - 1);
             });
         });


### PR DESCRIPTION
При уничтожении элемента (модели) содержащегося в `ns.ModelCollection` в событие `ns-mode-remove` попадала модель, которая была уже уничтожена (очищена). Это создает некоторые трудности при обработке события, т.к. в обработчик может приходить уже невалидная модель. Данный пулл исправляет поведение, передавая `ns-model-remove` ещё валидную модель.