### PR TITLE
[ns.Model] Возможность исправлять ошибки запроса

### DIFF
--- a/src/ns.request.js
+++ b/src/ns.request.js
@@ -334,7 +334,7 @@
             // это не означает, что завершится весь ns.request
             ns.request.manager.done(model);
 
-            model.promise.fulfill();
+            model.finishRequest();
         }
     };
 


### PR DESCRIPTION
Например, запросы подписываеются временным token. Если токен протух, то модель прозрачно может его перезапросить и сделать перезапрос себя.

Появилось два метода, isErrorCanBeFixed и fixError. Схема их работы должна быть понятная из тестов https://github.com/yandex-ui/noscript/commit/b2e9fdc0e6beefa2d1221cc4002d918dc61c12b3#diff-99cdcb9731e322f18306a7cc2abce3b8R1019