### PR TITLE
[ns.request] Поправил поведение при передаче экземпляров моделей

### DIFF
--- a/src/ns.request.js
+++ b/src/ns.request.js
@@ -2,11 +2,19 @@
 
     /**
      * Делает запрос моделей с сервера.
-     * Аргументы можно передавать в 3 форматах:
+     * Аргументы можно передавать в следующих форматах:
      *   - string item, params - одна модель и опциональные параметры для нее
-     *   - array item[], params - массив моделей и опциональные единые для всех параметры
-     *   - array item[] - массив моделей вида {id: modelName, params: modelParams}
-     * @param {String|Array|Object} items Массив названий моделей.
+     *     ns.request('model', params)
+     *   - string[], params - массив моделей и опциональные единые для всех параметры
+     *     ns.request(['model1', 'model2'], params)
+     *   - object[] - массив моделей вида {id: modelName, params: modelParams}
+     *     ns.request([
+     *       {id: 'model1', params: params1},
+     *       {id: 'model2', params: params2},
+     *     ])
+     *   - ns.Model[] - массив экземпляров моделей
+     *     ns.request([ modelInstance1, modelInstance2 ]);
+     * @param {String|Array} items Массив названий моделей.
      * @param {object} [params] Параметры моделей.
      * @param {object} [options] Опции запроса.
      * @param {Boolean} [options.forced=false] Не учитывать закешированность моделей при запросе.
@@ -20,7 +28,7 @@
     /**
      * Делает запрос моделей с сервера, не учитывая их закешированности.
      * @see ns.request
-     * @param {String|Array|Object} items Массив названий моделей.
+     * @param {String|Array} items Массив названий моделей.
      * @param {object} [params] Параметры моделей.
      * @param {object} [options] Опции запроса.
      * @param {Boolean} [options.forced=false] Не учитывать закешированность моделей при запросе.
@@ -401,8 +409,13 @@
         var models = [];
         for (var i = 0, l = items.length; i < l; i++) {
             var item = items[i];
-            if (item.model && item.model instanceof ns.Model) {
+            // ns.request( [ ModelInstance ] )
+            if (item instanceof ns.Model) {
+                models.push(item);
+
+            } else if (item.model && item.model instanceof ns.Model) {
                 models.push(item.model);
+
             } else {
                 models.push(ns.Model.get(item.id, item.params));
             }

--- a/test/spec/ns.request.js
+++ b/test/spec/ns.request.js
@@ -120,6 +120,42 @@ describe('ns.request.js', function() {
             });
         });
 
+        describe('ns.request( [modelInstance] ) ->', function() {
+
+            beforeEach(function() {
+                ns.Model.define('model');
+
+                this.modelInstance = ns.Model.get('model');
+                ns.request([this.modelInstance]);
+            });
+
+            it('should call ns.request.models once', function() {
+                expect(ns.request.models).to.have.callCount(1);
+            });
+
+            it('should call ns.request.models with given model instance', function() {
+                expect(ns.request.models).to.be.calledWith([this.modelInstance]);
+            });
+        });
+
+        describe('ns.request( [doModelInstance] ) ->', function() {
+
+            beforeEach(function() {
+                ns.Model.define('do-model');
+
+                this.modelInstance = ns.Model.get('do-model');
+                ns.request([this.modelInstance]);
+            });
+
+            it('should call ns.request.models once', function() {
+                expect(ns.request.models).to.have.callCount(1);
+            });
+
+            it('should call ns.request.models with given model instance', function() {
+                expect(ns.request.models).to.be.calledWith([this.modelInstance]);
+            });
+        });
+
     });
 
     describe('ns.forcedRequest', function() {


### PR DESCRIPTION
Если передать массив экземпляров моделей, то для обычных моделей выполнялся еще раз ns.Model.get, а для do-моделей создавался новый инстанс