### PR TITLE
#585: generateHTML returns main view node without ns-root wrapper

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,7 @@
     "eqnull": true,
     "immed": true,
     "indent": 4,
-    "latedef": true,
+    "latedef": false,
     "loopfunc": true,
     "newcap": true,
     "noarg": true,

--- a/src/ns.dom.js
+++ b/src/ns.dom.js
@@ -33,7 +33,7 @@
     };
 
     /**
-     * Generates DOM from HTML-string.
+     * Returns DOM node with children generated from HTML-string.
      * @param {string} html
      * @returns {?Element}
      */
@@ -45,7 +45,7 @@
         var div = document.createElement('div');
         div.innerHTML = html;
 
-        return div.firstChild;
+        return div;
     };
 
     /**

--- a/test/spec/ns.updater.js
+++ b/test/spec/ns.updater.js
@@ -136,7 +136,7 @@ describe('ns.Updater', function() {
                 this.update = new ns.Update(this.view, ns.layout.page('asyncLayout', {}), {});
                 this.update.generateHTML()
                     .then(function(html) {
-                        this.$node = $(ns.html2node(html));
+                        this.$node = $(html);
                         done();
                     }, this);
 
@@ -176,6 +176,10 @@ describe('ns.Updater', function() {
                 expect(arg).to.have.property('requestModels.0').that.is.at.least(0);
                 expect(arg).to.have.property('collectViews').that.is.at.least(0);
                 expect(arg).to.have.property('generateHTML').that.is.at.least(0);
+            });
+
+            it('should return ns-view-app as a root node', function() {
+                expect(this.$node.hasClass('ns-view-app')).to.be.ok();
             });
         });
 

--- a/test/spec/ns.view.js
+++ b/test/spec/ns.view.js
@@ -203,11 +203,8 @@ describe('ns.View', function() {
         beforeEach(function() {
             ns.View.define('some-view', {});
             this.view = ns.View.create('some-view');
-            this.testHtml =
-                '<div class="ns-root">' +
-                    '<div class="ns-view-some-view ' + this.view.__uniqueId + '" data-key="' + this.view.key + '"></div>' +
-                '</div>';
-            this.testNode = $(this.testHtml)[0];
+            this.testHtml = '<div class="ns-view-some-view ' + this.view.__uniqueId + '" data-key="' + this.view.key + '"></div>';
+            this.testNode = ns.html2node(this.testHtml);
             this.resultNode = $(this.testNode).children()[0];
         });
 
@@ -231,11 +228,8 @@ describe('ns.View', function() {
             ns.View.define('some-view', {});
 
             this.view = ns.View.create('some-view');
-            this.testHtml =
-                '<div class="ns-root">' +
-                    '<div class="ns-view-some-view ' + this.view.__uniqueId + '" data-key="' + this.view.key + '"></div>' +
-                '</div>';
-            this.testNode = $(this.testHtml)[0];
+            this.testHtml = '<div class="ns-view-some-view ' + this.view.__uniqueId + '" data-key="' + this.view.key + '"></div>';
+            this.testNode = ns.html2node(this.testHtml);
             this.resultNode = $(this.testNode).children()[0];
 
             this.sinon.spy(this.view, '_extractNodeByKey');

--- a/yate/noscript.yate
+++ b/yate/noscript.yate
@@ -32,9 +32,7 @@ key modelError( /.models.*[ .status == 'error' ], name() ) {
 
 // @private
 match / {
-    <div class="ns-root">
-        apply .views.* ns-view
-    </div>
+    apply .views.* ns-view
 }
 
 // делает chroot для view и генерит обертку с помощью ns-build-view


### PR DESCRIPTION
Кажется, `generateHTML` не должен возвращать дерево видов, обернутое в `ns-root` — ожидаешь получить html, готовый для вставки непосредственно в определенную ноду в серверном шаблоне, а `ns-root` это служебная обертка для удобного поиска в методах `_extractNode` и `_extractNodeByKey`.

Избавился от обертки в яте, перенеся ее в `ns.html2node`. По сути, метод должен принимать html-строку и вернуть дом-ноду, детками которой будет DOM, полученный из этого html, соответственно, этот метод и должен думать про корневую ноду, а не яте-шаблон. 