### PR TITLE
fix jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,7 @@
     "eqnull": true,
     "immed": true,
     "indent": 4,
-    "latedef": true,
+    "latedef": false,
     "loopfunc": true,
     "newcap": true,
     "noarg": true,


### PR DESCRIPTION
Во всех пул реквестах травис ругается на ошибки кодстайла и не запускает тесты. Все дело в `latedef`, которое везде используется (function declaration в замыкании зачастую опускаются в конец файла).

Давайте подмерджим в мастер, чтобы тесты в трависе в существующих пулах перестали врать.