### PR TITLE
[ns.View] Поддержка анимации у видов

### DIFF
--- a/src/ns.box.js
+++ b/src/ns.box.js
@@ -193,7 +193,7 @@ ns.Box.prototype._hideInactiveViews = function() {
             // вид может не быть отрисован,
             // но уже уйти в скрытие
             if (view.node) {
-                ns.removeNode(view.node);
+                ns.View.removeViewNode(view, false);
             }
 
             // Скроем виды, не попавшие в layout
@@ -369,16 +369,7 @@ ns.Box.prototype.destroy = function() {
     }
 
     if (this.node) {
-        $(this.node)
-            // события
-            .off()
-            // данные
-            .removeData()
-            // удаляем из DOM
-            .remove();
-
-        this.node = null;
-        this.$node = null;
+        ns.View.removeViewNode(this, true);
     }
 
     this.active = null;


### PR DESCRIPTION
Тут такая идея про то, как анимировать вид перед скрытием:
```(js)
ns.View.define('some-view', {
    animateBeforeHide: function() {
        var promise = doSomeAnimation();
        return promise;
    }
});
```
и в коде там где у нас нода вида / бокса меняется сделать вместо:
```js
this.$node
    // события
    .off()
    // данные
    .removeData()
    // удаляем из DOM
    .remove();
```
сделать так:
```js
var $oldNode = this.$node;
$oldNode.off(); // события
this. animateBeforeHide().then(function() {
    $oldNode
        // данные
        .removeData()
        // удаляем из DOM
        .remove();
});
```

/cc @shirokoff @Katochimoto @vitkarpov 