### PR TITLE
[ns.Events] Неверно работает ns.Events.once

### DIFF
--- a/src/ns.events.js
+++ b/src/ns.events.js
@@ -33,13 +33,14 @@ ns.Events.on = function(name, handler) {
  * @param {function} handler Обработчик события.
  * @returns {ns.Events}
  */
-ns.Events.once = function( name, handler ) {
+ns.Events.once = function(name, handler) {
     var that = this;
     var once = function() {
         that.off( name, once );
         handler.apply(this, arguments);
     };
-    this.on( name, once );
+    once.__original = handler;
+    this.on(name, once);
     return this;
 };
 
@@ -56,11 +57,12 @@ ns.Events.off = function(name, handler) {
         handlers = this._nsevents_handlers && this._nsevents_handlers[name];
         if (handlers) {
             //  Ищем этот хэндлер среди уже забинженных обработчиков этого события.
-            var i = handlers.indexOf(handler);
-
-            if (i !== -1) {
-                //  Нашли и удаляем этот обработчик.
-                handlers.splice(i, 1);
+            for (var i = 0, l = handlers.length; i < l; i++) {
+                if (handlers[i] === handler || handlers[i].__original === handler) {
+                    //  Нашли и удаляем этот обработчик.
+                    handlers.splice(i, 1);
+                    break;
+                }
             }
         }
     } else {

--- a/test/spec/ns.events.js
+++ b/test/spec/ns.events.js
@@ -118,16 +118,39 @@ describe('ns.Events', function() {
         beforeEach(function() {
             this.spy = this.sinon.spy();
             ns.events.once('test', this.spy);
-            ns.events.trigger('test');
-            ns.events.trigger('test');
         });
 
         it('должен вызвать обработчик один раз', function() {
+            ns.events.trigger('test');
+            ns.events.trigger('test');
             expect(this.spy).to.have.callCount(1);
         });
 
         it('должен вызвать обработчик в контексте ns.events', function() {
+            ns.events.trigger('test');
             expect(this.spy.getCall(0).thisValue).to.be.equal(ns.events);
+        });
+
+        it('должен отписаться при вызове ns.events.off', function() {
+            ns.events.off('test', this.spy);
+            ns.events.trigger('test');
+            expect(this.spy).to.have.callCount(0);
+        });
+        it('двойной once', function() {
+            ns.events.once('test', this.spy);
+            ns.events.trigger('test');
+            expect(this.spy).to.have.callCount(2);
+        });
+        it('двойной once и off', function() {
+            ns.events.once('test', this.spy);
+            ns.events.off('test', this.spy);
+            ns.events.trigger('test');
+            expect(this.spy).to.have.callCount(1);
+        });
+        it('должен отписаться на off', function() {
+            ns.events.off('test');
+            ns.events.trigger('test');
+            expect(this.spy).to.have.callCount(0);
         });
 
     });


### PR DESCRIPTION
ns.events.off не отписывает once события.
Пример
```js
const say = () => console.log('yo')
ns.events.once('yo', say)
ns.events.off('yo', say)
ns.events.trigger('yo')

// says 'yo'
```

Добавил ссылку на оригинальный обработчик и поправил off.