### PR TITLE
[ns.history] Не обрабатывать переход по ссылке, если нет hostname (IE11)

### DIFF
--- a/src/ns.history.js
+++ b/src/ns.history.js
@@ -83,6 +83,10 @@
             return true;
         }
 
+        if (!/^https?:/.test(target.protocol)) {
+            return true;
+        }
+
         // если hostname ссылки не равен нашему хосту, то она внешняя и ее обрабатывать не надо
         if (target.hostname && target.hostname !== window.location.hostname) {
             return true;

--- a/src/ns.history.js
+++ b/src/ns.history.js
@@ -87,7 +87,9 @@
             return true;
         }
 
-        // если hostname ссылки не равен нашему хосту, то она внешняя и ее обрабатывать не надо
+        // не обрабываем переход по ссылке:
+        // - если это внешняя ссылка
+        // - если hostname пустой (IE11 для относительных ссылок)
         if (target.hostname && target.hostname !== window.location.hostname) {
             return true;
         }

--- a/src/ns.history.js
+++ b/src/ns.history.js
@@ -84,7 +84,7 @@
         }
 
         // если hostname ссылки не равен нашему хосту, то она внешняя и ее обрабатывать не надо
-        if (target.hostname !== window.location.hostname) {
+        if (target.hostname && target.hostname !== window.location.hostname) {
             return true;
         }
 

--- a/test/spec/ns.history.js
+++ b/test/spec/ns.history.js
@@ -45,6 +45,13 @@ describe('ns.history', function() {
             ns.history._onAnchorClick(this.event);
             expect(ns.history.followAnchorHref).to.have.callCount(0);
         });
+
+        it('не должен перейти по ссылке, если href=javascript:void(0)', function() {
+            this.event.currentTarget.href = 'javascript:void(0)';
+
+            ns.history._onAnchorClick(this.event);
+            expect(ns.history.followAnchorHref).to.have.callCount(0);
+        });
     });
 
 });

--- a/test/spec/ns.history.js
+++ b/test/spec/ns.history.js
@@ -4,6 +4,7 @@ describe('ns.history', function() {
 
         beforeEach(function() {
             this.sinon.stub(ns.history, 'followAnchorHref');
+            this.sinon.stub(ns.router, 'baseDir', '/my/');
 
             this.event = {
                 currentTarget: document.createElement('a')
@@ -11,7 +12,6 @@ describe('ns.history', function() {
         });
 
         it('должен перейти по ссылке, если baseDir совпадает частично', function() {
-            this.sinon.stub(ns.router, 'baseDir', '/my/');
             this.event.currentTarget.href = '/my/page1';
 
             ns.history._onAnchorClick(this.event);
@@ -19,7 +19,6 @@ describe('ns.history', function() {
         });
 
         it('должен перейти по ссылке, если baseDir совпадает полностью', function() {
-            this.sinon.stub(ns.router, 'baseDir', '/my/');
             this.event.currentTarget.href = '/my/';
 
             ns.history._onAnchorClick(this.event);
@@ -27,7 +26,6 @@ describe('ns.history', function() {
         });
 
         it('не должен перейти по ссылке, если baseDir не совпадает совсем', function() {
-            this.sinon.stub(ns.router, 'baseDir', '/my/');
             this.event.currentTarget.href = '/another/page1';
 
             ns.history._onAnchorClick(this.event);
@@ -35,7 +33,6 @@ describe('ns.history', function() {
         });
 
         it('не должен перейти по ссылке, если baseDir не совпадает частично', function() {
-            this.sinon.stub(ns.router, 'baseDir', '/my/');
             this.event.currentTarget.href = '/my';
 
             ns.history._onAnchorClick(this.event);
@@ -43,7 +40,6 @@ describe('ns.history', function() {
         });
 
         it('не должен перейти по ссылке, если baseDir совпадает, но задан атрибут target', function() {
-            this.sinon.stub(ns.router, 'baseDir', '/my/');
             this.event.currentTarget.target = '_self';
 
             ns.history._onAnchorClick(this.event);


### PR DESCRIPTION
- https://github.com/yandex-ui/noscript/issues/604
- https://github.com/yandex-ui/noscript/issues/608

Хотел написать тест на #604, но не получилось:

```js
this.event = {
  currentTarget: document.createElement('a')
};
this.event.currentTarget.href = '/my/page1';

// Затереть hostname совсем нельзя, фантом так не хочет. Можно только переопределить.
this.event.currentTarget.hostname = '';
```

Но фикс, вроде, понятный.