### PR TITLE
[ns.View] Бросать исключение, если меняются дети

### DIFF
--- a/src/ns.view.js
+++ b/src/ns.view.js
@@ -740,8 +740,12 @@
                 this._addView(view_id, updateParams, layoutViews[view_id].type);
             }
 
+            var parentId = this.id;
             this._apply(function(view, id) {
-                view._getRequestViews(updated, layoutViews[id], updateParams);
+                var views = layoutViews[id];
+
+                ns.View.assert(!!views, 13, [parentId]);
+                view._getRequestViews(updated, views, updateParams);
             });
         }
 
@@ -1906,7 +1910,8 @@
         9: 'Model %s is not defined!',
         10: 'Could not generate key for view %s',
         11: '#patchLayout MUST returns valid layout ID',
-        12: '#patchLayout MUST returns layout with ns.Box at top'
+        12: '#patchLayout MUST returns layout with ns.Box at top',
+        13: 'You cannot change children inside of a regular view. Maybe "%s" should be ns.Box.'
     };
 
     /**

--- a/test/spec/ns.view.layout.js
+++ b/test/spec/ns.view.layout.js
@@ -614,4 +614,36 @@ describe('ns.View dynamic layouts ->', function() {
 
     });
 
+    describe('При изменении деток у обычного вида', function() {
+        beforeEach(function() {
+            ns.layout.define('app1', {
+               'app': {
+                 'view2': {}
+               }
+            });
+            ns.layout.define('app2', {
+               'app': {
+                 'view3': {}
+               }
+            });
+
+            ns.View.define('app');
+            ns.View.define('view2');
+            ns.View.define('view3');
+
+            this.view = ns.View.create('app');
+
+            return new ns.Update(this.view, ns.layout.page('app1'), {}).render();
+        });
+
+        it('апдейт должен бросить понятное исключение', function() {
+            return new ns.Update(this.view, ns.layout.page('app2'), {})
+                .render()
+                .then(null, function(err) {
+                    expect(
+                        ns.assert.fail.bind(ns, 'ns.View', ns.View.ERROR_CODES[13], 'app')
+                    ).to.throw(err.message);
+                });
+        });
+    })
 });


### PR DESCRIPTION
Если существующий экземпляр вьюшки в новом апдейте поменял своих деток — что-то пошло не так.

Бросаем исключение: View "v2" not found among children of "v1". Check out layout!