### PR TITLE
В ИЕ11 не обрабатывается переход по относительной ссылке в _onAnchorClick

### DIFF
--- a/src/ns.history.js
+++ b/src/ns.history.js
@@ -83,7 +83,11 @@
             return true;
         }
 
-        if (!/^https?:/.test(target.protocol)) {
+        // не обрабатываем переход по ссылке
+        // если у ссылки нет протокола (случай href="javascript:void(0)")
+        // NOTE: В ИЕ11 ссылки созданные через document.createElement не имеют protocol,
+        // поэтому дополнительно необходимо проверить, что он вообще есть
+        if (target.protocol && !/^https?:/.test(target.protocol)) {
             return true;
         }
 


### PR DESCRIPTION
К сожалению, в фантоме нельзя удалить `protocol` у ссылки (всегда будет `:` как минимум), соответственно, строго говоря тест не получится написать.

Должно быть что-то типа такого:

```js
        it('должен перейти по ссылке, если baseDir совпадает частично', function() {
            this.event.currentTarget.href = '/my/page1';
            delete this.event.currentTarget.protocol;

            ns.history._onAnchorClick(this.event);
            expect(ns.history.followAnchorHref).to.be.calledWith('/my/page1');
        });
```

но в таком случае `protocol` будет равен `:`.