### PR TITLE
ns.VERSION is now generated and placed in ns.version.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea
-.version
 dist
 .DS_Store
 gh-pages

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ PACKAGE_VERSION = `node -p -e "require('./package.json').version"`
 
 # сборка для npm
 dist: build/*.js src/*.js | node_modules
-	rm -f .version
-	printf $(PACKAGE_VERSION) -n > .version
+	echo '// DO NOT CHANGE MANUALLY (use Makefile)' > src/ns.version.js
+	printf "ns.VERSION = '%s';\n" $(PACKAGE_VERSION) >> src/ns.version.js
+	echo '// DO NOT CHANGE MANUALLY' >> src/ns.version.js
 	mkdir -p dist
 	$(NPM_BIN)/borschik -i build/src.client.js -o dist/noscript.js -m no
 	$(NPM_BIN)/borschik -i build/src.client.js -o dist/noscript.min.js -m yes

--- a/build/src.client.js
+++ b/build/src.client.js
@@ -7,6 +7,7 @@
     /* borschik:include:../node_modules/nommon/lib/no.jpath.js */
 
     /* borschik:include:../src/ns.js */
+    /* borschik:include:../src/ns.version.js */
     /* borschik:include:../src/ns.consts.js */
     /* borschik:include:../src/ns.consts.events.js */
     /* borschik:include:../src/ns.consts.client.js */
@@ -35,7 +36,6 @@
 
     // ns.box должен подключаться после ns.view, т.к. берет методы из него
     /* borschik:include:../src/ns.box.js */
-    ns.VERSION = 'borschik:include:../.version';
 
     window.no = no;
     window.ns = ns;

--- a/build/src.server.js
+++ b/build/src.server.js
@@ -5,6 +5,7 @@ module.exports = function() {
     /* borschik:include:../src/vow.log.js */
 
     /* borschik:include:../src/ns.js */
+    /* borschik:include:../src/ns.version.js */
     /* borschik:include:../src/ns.consts.js */
     /* borschik:include:../src/ns.consts.events.js */
     /* borschik:include:../src/ns.entityify.js */
@@ -28,7 +29,6 @@ module.exports = function() {
 
     // ns.box должен подключаться после ns.view, т.к. берет методы из него
     /* borschik:include:../src/ns.box.js */
-    ns.VERSION = 'borschik:include:../.version';
 
     return ns;
 }

--- a/src/ns.version.js
+++ b/src/ns.version.js
@@ -1,0 +1,3 @@
+// DO NOT CHANGE MANUALLY (use Makefile)
+ns.VERSION = '0.8.10';
+// DO NOT CHANGE MANUALLY


### PR DESCRIPTION
Fix for #637