### PR TITLE
path не может содержать ?

### DIFF
--- a/test/spec/ns.router.js
+++ b/test/spec/ns.router.js
@@ -305,6 +305,8 @@ describe('ns.router', function() {
         test_route('/from/var/logs/nginx/copy|', { page: 'page', params: { dialog: 'copy', div: '|', 'from-path': '/var/logs/nginx' } } );
         test_route('/from/var/logs/nginx/copy', { page: 'page', params: { dialog: 'copy', 'from-path': '/var/logs/nginx' } } );
         test_route('/from/var/logs/nginx', { page: 'page', params: { 'from-path': '/var/logs/nginx' } } );
+        test_route('/from/var/logs/ng?inx', { page: 'page', params: { 'from-path': '/var/logs/ng?inx' } } );
+        test_route('/from/var/logs/ng?inx?foo=1&bar=2', { page: 'page', params: { 'from-path': '/var/logs/ng?inx', foo: 1, bar: 2 } } );
     });
 
     describe('encodeParamValue and decodeParamValue', function() {

--- a/test/spec/ns.router.js
+++ b/test/spec/ns.router.js
@@ -279,7 +279,7 @@ describe('ns.router', function() {
     describe('special case: parameter is a path', function() {
 
         beforeEach(function() {
-            ns.router.regexps.path = '(?:\\/[^\\/]+)+';
+            ns.router.regexps.path = '(?:\\/[^\\/\\?]+)+';
             ns.router.regexps.dialog = 'copy|move';
             ns.router.regexps.divider = '\\|';
 
@@ -306,7 +306,7 @@ describe('ns.router', function() {
         test_route('/from/var/logs/nginx/copy', { page: 'page', params: { dialog: 'copy', 'from-path': '/var/logs/nginx' } } );
         test_route('/from/var/logs/nginx', { page: 'page', params: { 'from-path': '/var/logs/nginx' } } );
         test_route('/from/var/logs/ng%3Finx', { page: 'page', params: { 'from-path': '/var/logs/ng?inx' } } );
-        test_route('/from/var/logs/ng%3Finx?foo=1&bar=2', { page: 'page', params: { 'from-path': '/var/logs/ng?inx', foo: 1, bar: 2 } } );
+        test_route('/from/var/logs/ng%3Finx?foo=1&bar=2', { page: 'page', params: { 'from-path': '/var/logs/ng?inx', foo: '1', bar: '2' } } );
     });
 
     describe('encodeParamValue and decodeParamValue', function() {

--- a/test/spec/ns.router.js
+++ b/test/spec/ns.router.js
@@ -279,7 +279,7 @@ describe('ns.router', function() {
     describe('special case: parameter is a path', function() {
 
         beforeEach(function() {
-            ns.router.regexps.path = '(?:\\/[^\\/\\?]+)+';
+            ns.router.regexps.path = '(?:\\/[^\\/]+)+';
             ns.router.regexps.dialog = 'copy|move';
             ns.router.regexps.divider = '\\|';
 
@@ -305,8 +305,8 @@ describe('ns.router', function() {
         test_route('/from/var/logs/nginx/copy|', { page: 'page', params: { dialog: 'copy', div: '|', 'from-path': '/var/logs/nginx' } } );
         test_route('/from/var/logs/nginx/copy', { page: 'page', params: { dialog: 'copy', 'from-path': '/var/logs/nginx' } } );
         test_route('/from/var/logs/nginx', { page: 'page', params: { 'from-path': '/var/logs/nginx' } } );
-        test_route('/from/var/logs/ng?inx', { page: 'page', params: { 'from-path': '/var/logs/ng?inx' } } );
-        test_route('/from/var/logs/ng?inx?foo=1&bar=2', { page: 'page', params: { 'from-path': '/var/logs/ng?inx', foo: 1, bar: 2 } } );
+        test_route('/from/var/logs/ng%3Finx', { page: 'page', params: { 'from-path': '/var/logs/ng?inx' } } );
+        test_route('/from/var/logs/ng%3Finx?foo=1&bar=2', { page: 'page', params: { 'from-path': '/var/logs/ng?inx', foo: 1, bar: 2 } } );
     });
 
     describe('encodeParamValue and decodeParamValue', function() {


### PR DESCRIPTION
Сейчас `path` (вообще говоря, кастомный Дисковый роут, но в тестах есть) не умеет матчится на путь с вопросиком в имени папки.

Проблема не проектная, т.к. *вообще говоря параметры не может содержать `?` в значении* — роутер начинает работать неверно.

Вторым коммитом здесь поправлю [регулярку `path`](https://github.com/yandex-ui/noscript/blob/9e7697db4b8a60a65da4674540631981936a03c8/test/spec/ns.router.js#L282), чтобы умела мачиться на вопрос, а третьим коммитом собственно сделаю фикс, чтобы параметры после `?` (второй тест) не пропадали.